### PR TITLE
Rollback on from_str to avoid error on conversion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mostro-core"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2021"
 license = "MIT"
 authors = ["Francisco Calderón <negrunch@grunch.dev>"]

--- a/src/order.rs
+++ b/src/order.rs
@@ -1,16 +1,28 @@
 use anyhow::{Ok, Result};
-use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use sqlx_crud::SqlxCrud;
 use std::fmt;
+use std::str::FromStr;
 use uuid::Uuid;
 
 /// Orders can be only Buy or Sell
-#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 pub enum Kind {
     Buy,
     Sell,
+}
+
+impl FromStr for Kind {
+    type Err = ();
+
+    fn from_str(kind: &str) -> std::result::Result<Self, Self::Err> {
+        match kind {
+            "Buy" => std::result::Result::Ok(Self::Buy),
+            "Sell" => std::result::Result::Ok(Self::Sell),
+            _ => Err(()),
+        }
+    }
 }
 
 impl fmt::Display for Kind {
@@ -20,7 +32,7 @@ impl fmt::Display for Kind {
 }
 
 /// Each status that an order can have
-#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 pub enum Status {
     Active,
     Canceled,
@@ -36,6 +48,30 @@ pub enum Status {
     WaitingBuyerInvoice,
     WaitingPayment,
     CooperativelyCanceled,
+}
+
+impl FromStr for Status {
+    type Err = ();
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "Active" => std::result::Result::Ok(Self::Active),
+            "Canceled" => std::result::Result::Ok(Self::Canceled),
+            "CanceledByAdmin" => std::result::Result::Ok(Self::CanceledByAdmin),
+            "SettledByAdmin" => std::result::Result::Ok(Self::SettledByAdmin),
+            "CompletedByAdmin" => std::result::Result::Ok(Self::CompletedByAdmin),
+            "Dispute" => std::result::Result::Ok(Self::Dispute),
+            "Expired" => std::result::Result::Ok(Self::Expired),
+            "FiatSent" => std::result::Result::Ok(Self::FiatSent),
+            "SettledHoldInvoice" => std::result::Result::Ok(Self::SettledHoldInvoice),
+            "Pending" => std::result::Result::Ok(Self::Pending),
+            "Success" => std::result::Result::Ok(Self::Success),
+            "WaitingBuyerInvoice" => std::result::Result::Ok(Self::WaitingBuyerInvoice),
+            "WaitingPayment" => std::result::Result::Ok(Self::WaitingPayment),
+            "CooperativelyCanceled" => std::result::Result::Ok(Self::CooperativelyCanceled),
+            _ => Err(()),
+        }
+    }
 }
 
 impl fmt::Display for Status {
@@ -86,8 +122,8 @@ impl Order {
     pub fn as_new_order(&self) -> NewOrder {
         NewOrder::new(
             Some(self.id),
-            Kind::from_str(&self.kind, true).unwrap(),
-            Status::from_str(&self.status, true).unwrap(),
+            Kind::from_str(&self.kind).unwrap(),
+            Status::from_str(&self.status).unwrap(),
             self.amount,
             self.fiat_code.clone(),
             self.fiat_amount,


### PR DESCRIPTION
Hi @grunch 

rollback on `from_str` using `std::str::FromStr`.

Now seems workin.