### PR TITLE
version bump and clap crate removed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mostro-core"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 license = "MIT"
 authors = ["Francisco Calderón <negrunch@grunch.dev>"]
@@ -24,4 +24,3 @@ sqlx = { version = "0.6.2", features = [
   "uuid",
 ] }
 sqlx-crud = { version = "0.3.2", features = ["runtime-tokio-rustls"] }
-clap = { version = "4.4.6", features = ["derive"] }


### PR DESCRIPTION
Hi @grunch,

bumped version to `3.8` and removed `Clap`