### PR TITLE
Update

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@ pub mod user;
 /// All messages broadcasted by Mostro daemon are Parameterized Replaceable Events
 /// and use 30078 as event kind
 pub const NOSTR_REPLACEABLE_EVENT_KIND: u64 = 30078;
+pub const PROTOCOL_MAJOR_VER: u8 = 1;
+pub const PROTOCOL_MINOR_VER: u8 = 0;
 
 #[cfg(test)]
 mod test {
@@ -19,7 +21,6 @@ mod test {
     fn test_message_order() {
         let uuid = uuid!("308e1272-d5f4-47e6-bd97-3504baea9c23");
         let test_message = Message::Order(MessageKind::new(
-            0,
             Some(uuid),
             None,
             Action::NewOrder,
@@ -38,7 +39,7 @@ mod test {
                 1627371434,
             ))),
         ));
-        let sample_message = r#"{"Order":{"version":0,"id":"308e1272-d5f4-47e6-bd97-3504baea9c23","pubkey":null,"action":"NewOrder","content":{"Order":{"id":"308e1272-d5f4-47e6-bd97-3504baea9c23","kind":"Sell","status":"Pending","amount":100,"fiat_code":"eur","fiat_amount":100,"payment_method":"SEPA","premium":1,"created_at":1627371434}}}}"#;
+        let sample_message = r#"{"Order":{"version_major":1,"version_minor":0,"id":"308e1272-d5f4-47e6-bd97-3504baea9c23","pubkey":null,"action":"NewOrder","content":{"Order":{"id":"308e1272-d5f4-47e6-bd97-3504baea9c23","kind":"Sell","status":"Pending","amount":100,"fiat_code":"eur","fiat_amount":100,"payment_method":"SEPA","premium":1,"created_at":1627371434}}}}"#;
         let message = Message::from_json(sample_message).unwrap();
         assert!(message.verify());
         let message_json = message.as_json().unwrap();

--- a/src/message.rs
+++ b/src/message.rs
@@ -52,7 +52,7 @@ pub enum Action {
     BuyerTookOrder,
     RateUser,
     CantDo,
-    Received,
+    VoteReceived,
     Dispute,
     AdminCancel,
     AdminSettle,
@@ -72,6 +72,7 @@ pub enum Message {
     Order(MessageKind),
     Dispute(MessageKind),
     CantDo(MessageKind),
+    Rate(MessageKind),
 }
 
 impl Message {
@@ -99,9 +100,26 @@ impl Message {
         Self::Dispute(kind)
     }
 
+    /// New rate user message
+    pub fn new_rate_user(
+        id: Option<Uuid>,
+        pubkey: Option<String>,
+        content: Option<Content>,
+    ) -> Self {
+        let kind = MessageKind::new(id, pubkey, Action::RateUser, content);
+
+        Self::Order(kind)
+    }
+
+    pub fn ack_rate_user(id: Option<Uuid>, pubkey: Option<String>) -> Self {
+        let kind = MessageKind::new(id, pubkey, Action::VoteReceived, None);
+
+        Self::Order(kind)
+    }
+
     /// New can't do template message message
-    pub fn cant_do(id: Option<Uuid>, pubkey: Option<String>) -> Self {
-        let kind = MessageKind::new(id, pubkey, Action::CantDo, None);
+    pub fn cant_do(id: Option<Uuid>, pubkey: Option<String>, content: Option<Content>) -> Self {
+        let kind = MessageKind::new(id, pubkey, Action::CantDo, content);
 
         Self::CantDo(kind)
     }
@@ -122,6 +140,7 @@ impl Message {
             Message::Dispute(k) => k,
             Message::Order(k) => k,
             Message::CantDo(k) => k,
+            Message::Rate(k) => k,
         }
     }
 
@@ -131,6 +150,7 @@ impl Message {
             Message::Dispute(a) => Some(a.get_action()),
             Message::Order(a) => Some(a.get_action()),
             Message::CantDo(a) => Some(a.get_action()),
+            Message::Rate(a) => Some(a.get_action()),
         }
     }
 
@@ -140,6 +160,7 @@ impl Message {
             Message::Order(m) => m.verify(),
             Message::Dispute(m) => m.verify(),
             Message::CantDo(m) => m.verify(),
+            Message::Rate(m) => m.verify(),
         }
     }
 }
@@ -255,7 +276,7 @@ impl MessageKind {
             | Action::DisputeInitiatedByYou
             | Action::DisputeInitiatedByPeer
             | Action::CooperativeCancelAccepted
-            | Action::Received
+            | Action::VoteReceived
             | Action::CantDo => {
                 matches!(&self.content, Some(Content::TextMessage(_)))
             }


### PR DESCRIPTION
Hi @grunch ,

Removed version from `Messagekind`, I think it better to have in `lib.rs` two const globally used:

```
pub const PROTOCOL_MAJOR_VER: u8 = 1;
pub const PROTOCOL_MINOR_VER: u8 = 0;
```

So simply every new message is created like that:

```
/// New message
    pub fn new(
        id: Option<Uuid>,
        pubkey: Option<String>,
        action: Action,
        content: Option<Content>,
    ) -> Self {
        Self {
            version_major: PROTOCOL_MAJOR_VER,
            version_minor: PROTOCOL_MINOR_VER,
            id,
            pubkey,
            action,
            content,
        }
    }
```

We can remove all version parameter from Mostro too, cleaner code imo.

Added also `CantDo` message as we said yesterday, in `Mostro` we use a lot, so a quick creator is nice for me.

Will clean Mostro from version parameter meanwhile.
