### PR TITLE
added default attrib to Order struct

### DIFF
--- a/src/order.rs
+++ b/src/order.rs
@@ -81,7 +81,7 @@ impl fmt::Display for Status {
 }
 
 /// Database representation of an order
-#[derive(Debug, FromRow, SqlxCrud, Deserialize, Serialize, Clone)]
+#[derive(Debug, Default, FromRow, SqlxCrud, Deserialize, Serialize, Clone)]
 #[external_id]
 pub struct Order {
     pub id: Uuid,


### PR DESCRIPTION
Hi @grunch ,

added default attribute to Order struct to remove `fn add_order` from `db.rs`