### PR TITLE
added to_string trait for Status and kind

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mostro-core"
-version = "0.4.8"
+version = "0.4.9"
 edition = "2021"
 license = "MIT"
 authors = ["Francisco Calderón <negrunch@grunch.dev>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,21 @@ mod test {
     use crate::message::{Action, Content, Message, MessageKind};
     use crate::order::{Kind, SmallOrder, Status};
     use uuid::uuid;
+    #[test]
+    fn test_status_string() {
+        assert_eq!(Status::Active.to_string(), "active");
+        assert_eq!(Status::CompletedByAdmin.to_string(), "completedbyadmin");
+        assert_eq!(Status::FiatSent.to_string(), "fiatsent");
+        assert_ne!(Status::Pending.to_string(), "Pending");
+    }
+
+    #[test]
+    fn test_kind_string() {
+        assert_ne!(Kind::Sell.to_string(), "active");
+        assert_eq!(Kind::Sell.to_string(), "sell");
+        assert_eq!(Kind::Buy.to_string(), "buy");
+        assert_ne!(Kind::Buy.to_string(), "active");
+    }
 
     #[test]
     fn test_message_order() {

--- a/src/order.rs
+++ b/src/order.rs
@@ -2,7 +2,6 @@ use anyhow::{Ok, Result};
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use sqlx_crud::SqlxCrud;
-use std::fmt;
 use std::str::FromStr;
 use uuid::Uuid;
 
@@ -25,9 +24,12 @@ impl FromStr for Kind {
     }
 }
 
-impl fmt::Display for Kind {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{self:?}")
+impl ToString for Kind {
+    fn to_string(&self) -> String {
+        match self {
+            Kind::Sell => String::from("sell"),
+            Kind::Buy => String::from("buy"),
+        }
     }
 }
 
@@ -48,6 +50,27 @@ pub enum Status {
     WaitingBuyerInvoice,
     WaitingPayment,
     CooperativelyCanceled,
+}
+
+impl ToString for Status {
+    fn to_string(&self) -> String {
+        match self {
+            Status::Active => String::from("active"),
+            Status::Canceled => String::from("canceled"),
+            Status::CanceledByAdmin => String::from("canceledbyadmin"),
+            Status::SettledByAdmin => String::from("settledbyadmin"),
+            Status::CompletedByAdmin => String::from("completedbyadmin"),
+            Status::Dispute => String::from("dispute"),
+            Status::Expired => String::from("expired"),
+            Status::FiatSent => String::from("fiatsent"),
+            Status::SettledHoldInvoice => String::from("settledholdinvoice"),
+            Status::Pending => String::from("pending"),
+            Status::Success => String::from("success"),
+            Status::WaitingBuyerInvoice => String::from("waitingbuyerinvoice"),
+            Status::WaitingPayment => String::from("waitingpayment"),
+            Status::CooperativelyCanceled => String::from("cooperativelycanceled"),
+        }
+    }
 }
 
 impl FromStr for Status {
@@ -71,12 +94,6 @@ impl FromStr for Status {
             "cooperativelycanceled" => std::result::Result::Ok(Self::CooperativelyCanceled),
             _ => Err(()),
         }
-    }
-}
-
-impl fmt::Display for Status {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{self:?}")
     }
 }
 


### PR DESCRIPTION
Hi @grunch ,

added `ToString` trait for `Status `and `Kind `enums, removed `Display ` trait which is automatic with ToString.

Bumped to 4.9

