### PR TITLE
Added info action for mostro infos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mostro-core"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 license = "MIT"
 authors = ["Francisco Calderón <negrunch@grunch.dev>"]

--- a/src/message.rs
+++ b/src/message.rs
@@ -65,6 +65,7 @@ pub enum Action {
     AdminAddSolver,
     AdminTakeDispute,
     AdminTookDispute,
+    Info,
 }
 
 impl fmt::Display for Action {
@@ -226,6 +227,7 @@ impl MessageKind {
                 matches!(&self.content, Some(Content::PaymentRequest(_, _)))
             }
             Action::TakeSell
+            | Action::Info
             | Action::TakeBuy
             | Action::FiatSent
             | Action::FiatSentOk


### PR DESCRIPTION
Hi @grunch ,

added an info action to send a nip33 event on request with @bilthon requested infos.

