### PR TITLE
fixes on mostro-core for range order

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -173,7 +173,7 @@ pub struct MessageKind {
     pub content: Option<Content>,
 }
 
-type Amount = i64;
+type Amount = u64;
 
 /// Message content
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -308,6 +308,7 @@ impl MessageKind {
         }
         match &self.content {
             Some(Content::PaymentRequest(_, _, amount)) => *amount,
+            Some(Content::Amount(amount)) => Some(*amount),
             _ => None,
         }
     }


### PR DESCRIPTION
@grunch 

fixes for `takesell` and `takebuy`.

Do you want to try to set this to u64 ( or u32 should be enough :smile: ):

```Rust
    pub fiat_amount: i64,
```

