### PR TITLE
revert type of amount to u64 to have a fixed compiling version of mostro

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -173,7 +173,7 @@ pub struct MessageKind {
     pub content: Option<Content>,
 }
 
-type Amount = u64;
+type Amount = i64;
 
 /// Message content
 #[derive(Debug, Deserialize, Serialize, Clone)]


### PR DESCRIPTION
Hi @grunch ,

as a starting point to have also a Mostro compiling version reverting to` u64 Amount`