### PR TITLE
Fix rating event data-label tag converted to z

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mostro-core"
-version = "0.5.13"
+version = "0.5.14"
 edition = "2021"
 license = "MIT"
 authors = ["Francisco Calderón <negrunch@grunch.dev>"]

--- a/src/rating.rs
+++ b/src/rating.rs
@@ -46,7 +46,7 @@ impl Rating {
             ("last_rating".to_string(), self.last_rating.to_string()),
             ("max_rate".to_string(), self.max_rate.to_string()),
             ("min_rate".to_string(), self.min_rate.to_string()),
-            ("data_label".to_string(), "rating".to_string()),
+            ("z".to_string(), "rating".to_string()),
         ];
 
         Ok(tags)


### PR DESCRIPTION
Hi @grunch 

this could be the issue when requesting rate event, event was published with `data-label` tag for rating and `mostro` queries for z tag.

