### PR TITLE
Additions to have dispute tokens

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mostro-core"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2021"
 license = "MIT"
 authors = ["Francisco Calderón <negrunch@grunch.dev>"]

--- a/src/message.rs
+++ b/src/message.rs
@@ -192,7 +192,7 @@ pub enum Content {
     Order(SmallOrder),
     PaymentRequest(Option<SmallOrder>, String, Option<Amount>),
     TextMessage(String),
-    Peer(Peer),
+    Peer(Peer, Option<u16>),
     RatingUser(u8),
     Amount(Amount),
     Dispute(Uuid),

--- a/src/order.rs
+++ b/src/order.rs
@@ -164,6 +164,8 @@ impl Order {
             self.buyer_invoice.clone(),
             Some(self.created_at),
             Some(self.expires_at),
+            None,
+            None,
         )
     }
 
@@ -194,6 +196,8 @@ pub struct SmallOrder {
     pub buyer_invoice: Option<String>,
     pub created_at: Option<i64>,
     pub expires_at: Option<i64>,
+    pub buyer_token: Option<u16>,
+    pub seller_token: Option<u16>,
 }
 
 #[allow(dead_code)]
@@ -215,6 +219,8 @@ impl SmallOrder {
         buyer_invoice: Option<String>,
         created_at: Option<i64>,
         expires_at: Option<i64>,
+        buyer_token: Option<u16>,
+        seller_token: Option<u16>,
     ) -> Self {
         Self {
             id,
@@ -232,6 +238,8 @@ impl SmallOrder {
             buyer_invoice,
             created_at,
             expires_at,
+            buyer_token,
+            seller_token,
         }
     }
     /// New order from json string


### PR DESCRIPTION
Hi @grunch , @Catrya 

added some data in structs `SmallOrder` and in `Peer` enum to have the dispute tokens.
Simply a quick implementation, maybe we can do it better. Looking [here](https://github.com/lnp2pBot/bot/pull/546) seems that tokens are not saved on a db, so I did a quick generation of random number in the u16 range and sent the message to buyer, seller and admin who takes dispute. Messages are sent when admin takes the dispute, don't know if this is the desired behaviour and maybe we need to send messages when dispute is opened.

Let me know.

Did not test now because I will be AFK til the evening now.