### PR TITLE
added request_id to message for client testing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ mod test {
     fn test_order_message() {
         let uuid = uuid!("308e1272-d5f4-47e6-bd97-3504baea9c23");
         let test_message = Message::Order(MessageKind::new(
+            1,
             Some(uuid),
             Action::NewOrder,
             Some(Content::Order(SmallOrder::new(
@@ -56,7 +57,7 @@ mod test {
                 None,
             ))),
         ));
-        let sample_message = r#"{"order":{"version":1,"id":"308e1272-d5f4-47e6-bd97-3504baea9c23","pubkey":null,"action":"new-order","content":{"order":{"id":"308e1272-d5f4-47e6-bd97-3504baea9c23","kind":"sell","status":"pending","amount":100,"fiat_code":"eur","fiat_amount":100,"payment_method":"SEPA","premium":1,"created_at":1627371434}}}}"#;
+        let sample_message = r#"{"order":{"version":1,"request_id":1,"id":"308e1272-d5f4-47e6-bd97-3504baea9c23","pubkey":null,"action":"new-order","content":{"order":{"id":"308e1272-d5f4-47e6-bd97-3504baea9c23","kind":"sell","status":"pending","amount":100,"fiat_code":"eur","fiat_amount":100,"payment_method":"SEPA","premium":1,"created_at":1627371434}}}}"#;
         let message = Message::from_json(sample_message).unwrap();
         assert!(message.verify());
         let message_json = message.as_json().unwrap();
@@ -68,6 +69,7 @@ mod test {
     fn test_payment_request_content_message() {
         let uuid = uuid!("308e1272-d5f4-47e6-bd97-3504baea9c23");
         let test_message = Message::Order(MessageKind::new(
+            1,
             Some(uuid),
             Action::PayInvoice,
             Some(Content::PaymentRequest(
@@ -94,7 +96,7 @@ mod test {
                 None,
             )),
         ));
-        let sample_message = r#"{"order":{"version":1,"id":"308e1272-d5f4-47e6-bd97-3504baea9c23","pubkey":null,"action":"pay-invoice","content":{"payment_request":[{"id":"308e1272-d5f4-47e6-bd97-3504baea9c23","kind":"sell","status":"waiting-payment","amount":100,"fiat_code":"eur","fiat_amount":100,"payment_method":"SEPA","premium":1,"created_at":1627371434},"lnbcrt78510n1pj59wmepp50677g8tffdqa2p8882y0x6newny5vtz0hjuyngdwv226nanv4uzsdqqcqzzsxqyz5vqsp5skn973360gp4yhlpmefwvul5hs58lkkl3u3ujvt57elmp4zugp4q9qyyssqw4nzlr72w28k4waycf27qvgzc9sp79sqlw83j56txltz4va44j7jda23ydcujj9y5k6k0rn5ms84w8wmcmcyk5g3mhpqepf7envhdccp72nz6e",null]}}}"#;
+        let sample_message = r#"{"order":{"version":1,"request_id":1,"id":"308e1272-d5f4-47e6-bd97-3504baea9c23","pubkey":null,"action":"pay-invoice","content":{"payment_request":[{"id":"308e1272-d5f4-47e6-bd97-3504baea9c23","kind":"sell","status":"waiting-payment","amount":100,"fiat_code":"eur","fiat_amount":100,"payment_method":"SEPA","premium":1,"created_at":1627371434},"lnbcrt78510n1pj59wmepp50677g8tffdqa2p8882y0x6newny5vtz0hjuyngdwv226nanv4uzsdqqcqzzsxqyz5vqsp5skn973360gp4yhlpmefwvul5hs58lkkl3u3ujvt57elmp4zugp4q9qyyssqw4nzlr72w28k4waycf27qvgzc9sp79sqlw83j56txltz4va44j7jda23ydcujj9y5k6k0rn5ms84w8wmcmcyk5g3mhpqepf7envhdccp72nz6e",null]}}}"#;
         let message = Message::from_json(sample_message).unwrap();
         assert!(message.verify());
         let message_json = message.as_json().unwrap();

--- a/src/message.rs
+++ b/src/message.rs
@@ -95,22 +95,32 @@ pub enum Message {
 
 impl Message {
     /// New order message
-    pub fn new_order(id: Option<Uuid>, action: Action, content: Option<Content>) -> Self {
-        let kind = MessageKind::new(id, action, content);
+    pub fn new_order(
+        request_id: u64,
+        id: Option<Uuid>,
+        action: Action,
+        content: Option<Content>,
+    ) -> Self {
+        let kind = MessageKind::new(request_id, id, action, content);
 
         Self::Order(kind)
     }
 
     /// New dispute message
-    pub fn new_dispute(id: Option<Uuid>, action: Action, content: Option<Content>) -> Self {
-        let kind = MessageKind::new(id, action, content);
+    pub fn new_dispute(
+        request_id: u64,
+        id: Option<Uuid>,
+        action: Action,
+        content: Option<Content>,
+    ) -> Self {
+        let kind = MessageKind::new(request_id, id, action, content);
 
         Self::Dispute(kind)
     }
 
     /// New can't do template message message
-    pub fn cant_do(id: Option<Uuid>, content: Option<Content>) -> Self {
-        let kind = MessageKind::new(id, Action::CantDo, content);
+    pub fn cant_do(request_id: u64, id: Option<Uuid>, content: Option<Content>) -> Self {
+        let kind = MessageKind::new(request_id, id, Action::CantDo, content);
 
         Self::CantDo(kind)
     }
@@ -161,6 +171,8 @@ impl Message {
 pub struct MessageKind {
     /// Message version
     pub version: u8,
+    /// Request_id for test on client
+    pub request_id: u64,
     /// Message id is not mandatory
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<Uuid>,
@@ -188,9 +200,15 @@ pub enum Content {
 #[allow(dead_code)]
 impl MessageKind {
     /// New message
-    pub fn new(id: Option<Uuid>, action: Action, content: Option<Content>) -> Self {
+    pub fn new(
+        request_id: u64,
+        id: Option<Uuid>,
+        action: Action,
+        content: Option<Content>,
+    ) -> Self {
         Self {
             version: PROTOCOL_VER,
+            request_id,
             id,
             action,
             content,


### PR DESCRIPTION
@grunch @bilthon ,

added an `u64` named request_id in messages of `mostro-core` to evaluate the delay noticed in client interfaces.

```Rust
pub struct MessageKind {
    /// Message version
    pub version: u8,
    /// Request_id for test on client
    pub request_id: u64,
    /// Message id is not mandatory
    #[serde(skip_serializing_if = "Option::is_none")]
    pub id: Option<Uuid>,
    /// Action to be taken
    pub action: Action,
    /// Message content
    pub content: Option<Content>,
}
```

