### PR TITLE
Bump `nostr-sdk` to `v0.36.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ sqlx-crud = { version = "0.4.0", features = [
   "runtime-tokio-rustls",
 ], optional = true }
 wasm-bindgen = { version = "0.2.92", optional = true }
-nostr-sdk = "0.32.0"
+nostr-sdk = "0.36.0"
 
 [features]
 default = ["wasm"]

--- a/src/rating.rs
+++ b/src/rating.rs
@@ -40,7 +40,7 @@ impl Rating {
     }
 
     /// Transform Rating struct to tuple vector to easily interact with Nostr
-    pub fn to_tags(&self) -> Result<Vec<Tag>> {
+    pub fn to_tags(&self) -> Result<Tags> {
         let tags = vec![
             Tag::custom(
                 TagKind::Custom(std::borrow::Cow::Borrowed("total_reviews")),
@@ -68,25 +68,25 @@ impl Rating {
             ),
         ];
 
-        Ok(tags)
+        Ok(Tags::new(tags))
     }
 
     /// Transform tuple vector to Rating struct
-    pub fn from_tags(tags: Vec<Tag>) -> Result<Self> {
+    pub fn from_tags(tags: Tags) -> Result<Self> {
         let mut total_reviews = 0;
         let mut total_rating = 0.0;
         let mut last_rating = 0;
         let mut max_rate = 0;
         let mut min_rate = 0;
 
-        for tag in tags {
+        for tag in tags.into_iter() {
             let t = tag.to_vec();
             match t.first().unwrap().as_str() {
-                "total_reviews" => total_reviews = t.get(1).unwrap().parse::<u64>().unwrap(),
-                "total_rating" => total_rating = t.get(1).unwrap().parse::<f64>().unwrap(),
-                "last_rating" => last_rating = t.get(1).unwrap().parse::<u8>().unwrap(),
-                "max_rate" => max_rate = t.get(1).unwrap().parse::<u8>().unwrap(),
-                "min_rate" => min_rate = t.get(1).unwrap().parse::<u8>().unwrap(),
+                "total_reviews" => total_reviews = t.get(1).unwrap().parse::<u64>()?,
+                "total_rating" => total_rating = t.get(1).unwrap().parse::<f64>()?,
+                "last_rating" => last_rating = t.get(1).unwrap().parse::<u8>()?,
+                "max_rate" => max_rate = t.get(1).unwrap().parse::<u8>()?,
+                "min_rate" => min_rate = t.get(1).unwrap().parse::<u8>()?,
                 _ => {}
             }
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `nostr-sdk` dependency to the latest version, enhancing compatibility and performance.
  
- **Bug Fixes**
	- Improved error handling in the `from_tags` method, allowing for better management of parsing errors.

- **Refactor**
	- Streamlined the `to_tags` and `from_tags` methods in the `Rating` struct for enhanced type safety and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->