### PR TITLE
Add trade key index to msg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mostro-core"
-version = "0.6.11"
+version = "0.6.12"
 edition = "2021"
 license = "MIT"
 authors = ["Francisco Calderón <negrunch@grunch.dev>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ sqlx-crud = { version = "0.4.0", features = [
 ], optional = true }
 wasm-bindgen = { version = "0.2.92", optional = true }
 nostr-sdk = "0.36.0"
+bitcoin = "0.32.5"
+bitcoin_hashes = "0.15.0"
 
 [features]
 default = ["wasm"]

--- a/src/message.rs
+++ b/src/message.rs
@@ -173,6 +173,8 @@ pub struct MessageKind {
     pub version: u8,
     /// Request_id for test on client
     pub request_id: Option<u64>,
+    /// Trade key index
+    pub trade_key_index: Option<u16>,
     /// Message id is not mandatory
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<Uuid>,

--- a/src/message.rs
+++ b/src/message.rs
@@ -362,16 +362,19 @@ impl MessageKind {
             Some(c) => c,
             _ => return false,
         };
+        // Get signature or return false if None
+        let sig = match self.get_signature() {
+            Some(s) => s,
+            _ => return false,
+        }; // Create message hash
         let json: Value = json!(content);
         let content_str: String = json.to_string();
         let hash: Sha256Hash = Sha256Hash::hash(content_str.as_bytes());
         let hash = hash.to_byte_array();
         let message: BitcoinMessage = BitcoinMessage::from_digest(hash);
-        let sig = match self.get_signature() {
-            Some(s) => s,
-            _ => return false,
-        };
-        let secp = Secp256k1::new();
+        // Create a verification-only context for better performance
+        let secp = Secp256k1::verification_only();
+        // Verify signature
         pubkey.verify(&secp, &message, sig).is_ok()
     }
 }

--- a/src/user.rs
+++ b/src/user.rs
@@ -17,6 +17,7 @@ pub struct User {
     pub is_banned: i64,
     pub category: i64,
     pub created_at: i64,
+    pub trade_index: u64,
 }
 
 impl User {
@@ -26,6 +27,7 @@ impl User {
         is_solver: i64,
         is_banned: i64,
         category: i64,
+        trade_index: u64
     ) -> Self {
         Self {
             id: Uuid::new_v4(),
@@ -35,6 +37,7 @@ impl User {
             is_banned,
             category,
             created_at: Utc::now().timestamp(),
+            trade_index
         }
     }
 }


### PR DESCRIPTION
    * Add bitcoin and bitcoin_hashes dependencies
    * Fix unit tests with new fields `trade_index`, `trade_index`, `signature` and new content type
    * Add verify_content_signature() message function to verify content's signature
    * Add test for verify_content_signature()
    * Code refactoring


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new dependencies for enhanced Bitcoin message handling and key management.
	- Added support for trade indexing and signature verification in message structures.
	- Enhanced `User` struct with a new `trade_index` field for improved user tracking.

- **Bug Fixes**
	- Improved message integrity and traceability through updated verification methods.

- **Tests**
	- Expanded testing coverage for message handling, including new tests for content signature verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->