### PR TITLE
Added CantDoReason enum for payload of CantDo message

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mostro-core"
-version = "0.6.14"
+version = "0.6.15"
 edition = "2021"
 license = "MIT"
 authors = ["Francisco Calderón <negrunch@grunch.dev>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ pub const PROTOCOL_VER: u8 = 1;
 
 #[cfg(test)]
 mod test {
-    use crate::message::{Action, Message, MessageKind, Payload, Peer};
+    use crate::message::{Action, CantDoReason, Message, MessageKind, Payload, Peer};
     use crate::order::{Kind, SmallOrder, Status};
     use nostr_sdk::Keys;
     use uuid::uuid;
@@ -134,5 +134,20 @@ mod test {
         assert!(test_message
             .get_inner_message_kind()
             .verify_signature(trade_keys.public_key(), sig));
+    }
+
+    #[test]
+    fn test_cant_do_reason_serialization() {
+        let cant_do = Message::CantDo(MessageKind::new(
+            None,
+            None,
+            None,
+            Action::CantDo,
+            Some(Payload::CantDo(Some(CantDoReason::InvalidSignature))),
+        ));
+        let json_cant_do_message = r#"{"cant-do":{"version":1,"request_id":null,"trade_index":null,"action":"cant-do","payload":{"cant_do":"invalid_signature"}}}"#;
+        let message = Message::from_json(json_cant_do_message).unwrap();
+        assert!(message.verify());
+        assert_eq!(message.as_json().unwrap(), cant_do.as_json().unwrap());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,16 +137,41 @@ mod test {
     }
 
     #[test]
-    fn test_cant_do_reason_serialization() {
+    fn test_cant_do_message_serialization() {
+        // Test all CantDoReason variants
+        let reasons = vec![
+            CantDoReason::InvalidSignature,
+            CantDoReason::InvalidTradeIndex,
+            CantDoReason::InvalidAmount,
+            CantDoReason::InvalidInvoice,
+            CantDoReason::InvalidPaymentRequest,
+            CantDoReason::InvalidPeer,
+            CantDoReason::InvalidRating,
+            CantDoReason::InvalidTextMessage,
+        ];
+
+        for reason in reasons {
+            let cant_do = Message::CantDo(MessageKind::new(
+                None,
+                None,
+                None,
+                Action::CantDo,
+                Some(Payload::CantDo(Some(reason.clone()))),
+            ));
+            let message = Message::from_json(&cant_do.as_json().unwrap()).unwrap();
+            assert!(message.verify());
+            assert_eq!(message.as_json().unwrap(), cant_do.as_json().unwrap());
+        }
+
+        // Test None case
         let cant_do = Message::CantDo(MessageKind::new(
             None,
             None,
             None,
             Action::CantDo,
-            Some(Payload::CantDo(Some(CantDoReason::InvalidSignature))),
+            Some(Payload::CantDo(None)),
         ));
-        let json_cant_do_message = r#"{"cant-do":{"version":1,"request_id":null,"trade_index":null,"action":"cant-do","payload":{"cant_do":"invalid_signature"}}}"#;
-        let message = Message::from_json(json_cant_do_message).unwrap();
+        let message = Message::from_json(&cant_do.as_json().unwrap()).unwrap();
         assert!(message.verify());
         assert_eq!(message.as_json().unwrap(), cant_do.as_json().unwrap());
     }

--- a/src/message.rs
+++ b/src/message.rs
@@ -192,16 +192,25 @@ pub struct MessageKind {
 
 type Amount = i64;
 
+/// Represents specific reasons why a requested action cannot be performed
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum CantDoReason {
+    /// The provided signature is invalid or missing
     InvalidSignature,
+    /// The specified trade index does not exist or is invalid
     InvalidTradeIndex,
+    /// The provided amount is invalid or out of acceptable range
     InvalidAmount,
+    /// The provided invoice is malformed or expired
     InvalidInvoice,
+    /// The payment request is invalid or cannot be processed
     InvalidPaymentRequest,
+    /// The specified peer is invalid or not found
     InvalidPeer,
+    /// The rating value is invalid or out of range
     InvalidRating,
+    /// The text message is invalid or contains prohibited content
     InvalidTextMessage,
 }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -193,7 +193,7 @@ pub struct MessageKind {
 type Amount = i64;
 
 /// Represents specific reasons why a requested action cannot be performed
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum CantDoReason {
     /// The provided signature is invalid or missing

--- a/src/message.rs
+++ b/src/message.rs
@@ -312,7 +312,7 @@ impl MessageKind {
                 matches!(&self.payload, Some(Payload::RatingUser(_)))
             }
             Action::CantDo => {
-                matches!(&self.payload, Some(Payload::TextMessage(_)))
+                matches!(&self.payload, Some(Payload::CantDo(_)))
             }
         }
     }

--- a/src/message.rs
+++ b/src/message.rs
@@ -192,6 +192,19 @@ pub struct MessageKind {
 
 type Amount = i64;
 
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum CantDoReason {
+    InvalidSignature,
+    InvalidTradeIndex,
+    InvalidAmount,
+    InvalidInvoice,
+    InvalidPaymentRequest,
+    InvalidPeer,
+    InvalidRating,
+    InvalidTextMessage,
+}
+
 /// Message payload
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
@@ -203,6 +216,7 @@ pub enum Payload {
     RatingUser(u8),
     Amount(Amount),
     Dispute(Uuid, Option<u16>),
+    CantDo(Option<CantDoReason>),
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
Hi @grunch @bilthon 

started to work on #69 creating this enums for `Payload` of `CantDo` generic messages to have info on the internal cause of rejecting actions requested.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new enum for clearer categorization of error messages.
	- Expanded the message handling capabilities with a new variant for more specific error reporting.
- **Tests**
	- Added a test for the serialization of the new error message variant.
- **Chores**
	- Updated package version from `0.6.14` to `0.6.15`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->