### PR TITLE
Remove of crud from users table

### DIFF
--- a/src/user.rs
+++ b/src/user.rs
@@ -2,14 +2,11 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "sqlx")]
 use sqlx::FromRow;
-#[cfg(feature = "sqlx")]
-use sqlx_crud::SqlxCrud;
 
 /// Database representation of an user
-#[cfg_attr(feature = "sqlx", derive(FromRow, SqlxCrud), external_id)]
+#[cfg_attr(feature = "sqlx", derive(FromRow))]
 #[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct User {
-    pub id: uuid::Uuid,
     pub pubkey: String,
     pub is_admin: i64,
     pub is_solver: i64,
@@ -36,7 +33,6 @@ impl User {
         trade_index: i64,
     ) -> Self {
         Self {
-            id: uuid::Uuid::new_v4(),
             pubkey,
             is_admin,
             is_solver,


### PR DESCRIPTION
Hi @grunch ,

with this removal of `CRUD` from users table in `mostro-core` I was able to have pubkey as primary key working. Crud crate was not working with String, but `sqlx` does.
We can think to improve CRUD later imo. Also using id as primary key was not meaningful in my opinion, this makes more sense.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated user creation process by removing the unique identifier from the user struct.
  
- **Bug Fixes**
	- Adjusted the initialization logic for user instances to align with the new struct definition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->