### PR TITLE
Fix: precision with native f64 value for total rating

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mostro-core"
-version = "0.6.18"
+version = "0.6.19"
 edition = "2021"
 license = "MIT"
 authors = ["Francisco Calderón <negrunch@grunch.dev>"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.82.0"
+profile = "minimal"
+components = ["clippy", "rust-docs", "rustfmt"]
+targets = ["wasm32-unknown-unknown"]

--- a/src/user.rs
+++ b/src/user.rs
@@ -5,7 +5,7 @@ use sqlx::FromRow;
 
 /// Database representation of an user
 #[cfg_attr(feature = "sqlx", derive(FromRow))]
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
 pub struct User {
     pub pubkey: String,
     pub is_admin: i64,
@@ -16,7 +16,7 @@ pub struct User {
     /// the trade_index is greater than the one we have in database
     pub last_trade_index: i64,
     pub total_reviews: i64,
-    pub total_rating: i64,
+    pub total_rating: f64,
     pub last_rating: i64,
     pub max_rating: i64,
     pub min_rating: i64,
@@ -40,7 +40,7 @@ impl User {
             category,
             last_trade_index: trade_index,
             total_reviews: 0,
-            total_rating: 0,
+            total_rating: 0.0,
             last_rating: 0,
             max_rating: 0,
             min_rating: 0,


### PR DESCRIPTION
Hi @grunch ,

as suggested by rabbit I added to `user` f64 native precision for total rating, I remove derive of `Eq` not supported by floating numbers and left `PartialEq` which should be ok for us. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `[toolchain]` section in the configuration file to specify Rust toolchain settings, including version, profile, components, and target architecture.

- **Bug Fixes**
	- Updated the `total_rating` field in the `User` struct to allow for decimal values, enhancing rating accuracy.

- **Chores**
	- Updated the package version of `mostro-core` from `0.6.18` to `0.6.19` to keep dependencies current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->