### PR TITLE
Add new cantdo reasons

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mostro-core"
-version = "0.6.20"
+version = "0.6.21"
 edition = "2021"
 license = "MIT"
 authors = ["Francisco Calderón <negrunch@grunch.dev>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,11 @@ mod test {
             CantDoReason::InvalidPeer,
             CantDoReason::InvalidRating,
             CantDoReason::InvalidTextMessage,
+            CantDoReason::InvalidOrderStatus,
+            CantDoReason::InvalidPubkey,
+            CantDoReason::InvalidParameters,
+            CantDoReason::OrderAlreadyCanceled,
+            CantDoReason::CantCreateUser,
         ];
 
         for reason in reasons {

--- a/src/message.rs
+++ b/src/message.rs
@@ -231,6 +231,16 @@ pub enum CantDoReason {
     InvalidTextMessage,
     /// The order kind is invalid
     InvalidOrderKind,
+    /// The order status is invalid
+    InvalidOrderStatus,
+    /// Invalid pubkey
+    InvalidPubkey,
+    /// Invalid parameters
+    InvalidParameters,
+    /// The order is already canceled
+    OrderAlreadyCanceled,
+    /// Can't create user
+    CantCreateUser,
 }
 
 /// Message payload


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new error variants to enhance error reporting: `InvalidOrderStatus`, `InvalidPubkey`, `InvalidParameters`, `OrderAlreadyCanceled`, and `CantCreateUser`.
  
- **Chores**
	- Updated package version of "mostro-core" from 0.6.20 to 0.6.21.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->