### PR TITLE
Add next trade fields to order

### DIFF
--- a/src/order.rs
+++ b/src/order.rs
@@ -146,6 +146,8 @@ pub struct Order {
     pub expires_at: i64,
     pub trade_index_seller: Option<i64>,
     pub trade_index_buyer: Option<i64>,
+    pub next_trade_pubkey: Option<String>,
+    pub next_trade_index: Option<i64>,
 }
 
 impl Order {


### PR DESCRIPTION
These values are send to Mostro by the client on the message with action FiatSent when the buyer is the maker, then Mostro will use these fields after the release