### PR TITLE
Fix #447 - orders with premium are rejected

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -51,6 +51,8 @@ pub enum CantDoReason {
     InvalidDisputeStatus,
     /// Invalid action
     InvalidAction,
+    /// Pending order exists
+    PendingOrderExists,
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/src/order.rs
+++ b/src/order.rs
@@ -457,9 +457,9 @@ impl SmallOrder {
     /// Check if the order has a zero amount and a premium or fiat amount
     pub fn check_zero_amount_with_premium(&self) -> Result<(), CantDoReason> {
         let premium = (self.premium != 0).then_some(self.premium);
-        let fiat_amount = (self.fiat_amount != 0).then_some(self.fiat_amount);
+        let sats_amount = (self.amount != 0).then_some(self.amount);
 
-        if premium.is_some() && fiat_amount.is_some() {
+        if premium.is_some() && sats_amount.is_some() {
             return Err(CantDoReason::InvalidParameters);
         }
         Ok(())


### PR DESCRIPTION
@grunch @Catrya 

with these PR now we have:

```Bash
pinballwizard@pop-os:~/rust_prj/testMostroCli$ ./mostro-cli neworder -k sell -a 6000  -c usd -f 5 -m sepa -p 1
```
Result:
```Bash
INFO mostrod::util: Sending DM, Event ID: eb0b02d44b361396ea142f0798cb582343018804775d6bc043c90da9c8ce789e with payload: "{\"cant-do\":{\"version\":1,\"request_id\":11685684561320541688,\"trade_index\":null,\"action\":\"cant-do\",\"payload\":{\"cant_do\":\"invalid_parameters\"}}}"
```

While:

```Bash
pinballwizard@pop-os:~/rust_prj/testMostroCli$ ./mostro-cli neworder -k sell -c usd -f 5 -m sepa -p 1
```

Publishes correctly the order.

As a bonus and error in CantDo enumerate is added: `PendingOrderExists`