### PR TITLE
Added a parameter in SolverDisputeInfo creation

### DIFF
--- a/src/dispute.rs
+++ b/src/dispute.rs
@@ -105,6 +105,7 @@ impl SolverDisputeInfo {
     pub fn new(
         order: &Order,
         dispute: &Dispute,
+        initiator_tradekey: String,
         counterpart: &User,
         initiator: &User,
         initiator_operating_days: u64,
@@ -116,7 +117,7 @@ impl SolverDisputeInfo {
             status: order.status.clone(),
             hash: order.hash.clone(),
             preimage: order.preimage.clone(),
-            initiator_pubkey: initiator.pubkey.clone(),
+            initiator_pubkey: initiator_tradekey,
             buyer_pubkey: order.buyer_pubkey.clone(),
             buyer_token: dispute.buyer_token,
             seller_pubkey: order.seller_pubkey.clone(),


### PR DESCRIPTION
@Catrya ,

this is a fix on core to have the initiator pubkey correctly set with trade key of initiator not identity key.

Please do a round of test if you can, i will be a bit afk now and not tested it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the dispute resolution process by introducing a dedicated trade identifier for case initiation, ensuring improved tracking and data accuracy in dispute management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->