### PR TITLE
Rollback mostro-cor to Nostr sdk 0.38

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ sqlx-crud = { version = "0.4.0", features = [
   "runtime-tokio-rustls",
 ], optional = true }
 wasm-bindgen = { version = "0.2.92", optional = true }
-nostr-sdk = "0.39.0"
+nostr-sdk = "0.38.0"
 bitcoin = "0.32.5"
 bitcoin_hashes = "0.16.0"
 rand = "0.9.0"

--- a/src/message.rs
+++ b/src/message.rs
@@ -204,10 +204,7 @@ impl Message {
         // Create a verification-only context for better performance
         let secp = Secp256k1::verification_only();
         // Verify signature
-        pubkey
-            .xonly()
-            .map(|xonly| xonly.verify(&secp, &message, &sig).is_ok())
-            .unwrap_or(false)
+        pubkey.verify(&secp, &message, &sig).is_ok()
     }
 }
 


### PR DESCRIPTION
@grunch ,

this is the best thing I had in mind, i know you won't like it, but to merge disputes at the moment let's roll back to 0.38. 
Modification are trivial as you can see, basically just that `xonly()` introduced by Yuki in sdk 0.39.
 
I am preparing also a small project just to test the signature issue with both version and I spoke also with yuki about. 
In any case we have to find out the issue to move on with sdk versions, but for now let's add disputes with 0.38 as we said yesterday.

I did not touch version here so it's `6.32`. I let you decide if you want to move `6.33` or not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

We’ve made behind‐the‐scenes improvements for a more reliable experience.

- **Chores**
  - Adjusted dependency management by switching to an earlier stable version of a key library, ensuring consistent performance.
- **Refactor**
  - Streamlined the signature verification process to yield a more direct and dependable outcome for users.

These enhancements maintain functionality while bolstering overall efficiency and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->