### PR TITLE
Bumped nostr sdk 40 to test with fix on mostro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ sqlx-crud = { version = "0.4.0", features = [
   "runtime-tokio-rustls",
 ], optional = true }
 wasm-bindgen = { version = "0.2.92", optional = true }
-nostr-sdk = "0.38.0"
+nostr-sdk = "0.40.0"
 bitcoin = "0.32.5"
 bitcoin_hashes = "0.16.0"
 rand = "0.9.0"

--- a/src/message.rs
+++ b/src/message.rs
@@ -201,10 +201,15 @@ impl Message {
         let hash: Sha256Hash = Sha256Hash::hash(message.as_bytes());
         let hash = hash.to_byte_array();
         let message: BitcoinMessage = BitcoinMessage::from_digest(hash);
+
         // Create a verification-only context for better performance
         let secp = Secp256k1::verification_only();
         // Verify signature
-        pubkey.verify(&secp, &message, &sig).is_ok()
+        if let Ok(xonlykey) = pubkey.xonly() {
+            xonlykey.verify(&secp, &message, &sig).is_ok()
+        } else {
+            false
+        }
     }
 }
 

--- a/src/rating.rs
+++ b/src/rating.rs
@@ -68,7 +68,9 @@ impl Rating {
             ),
         ];
 
-        Ok(Tags::new(tags))
+        let tags = Tags::from_list(tags);
+
+        Ok(tags)
     }
 
     /// Transform tuple vector to Rating struct


### PR DESCRIPTION
@grunch @Catrya ,

this, as usual, is neede to test `mostro` . This bumps `mostro-core` to nostr sdk 0.40 so it's ready also for the update of `mostro-cli` of @grunch .



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded a key dependency to ensure improved compatibility.
- **Refactor**
  - Enhanced signature validation logic for more reliable security checks.
  - Updated tag processing for more consistent and predictable categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->