### PR TITLE
Feaure privacy range order

### DIFF
--- a/src/order.rs
+++ b/src/order.rs
@@ -339,6 +339,21 @@ impl Order {
     pub fn set_timestamp_now(&mut self) {
         self.taken_at = Timestamp::now().as_u64() as i64
     }
+
+    /// check if a user is creating a full privacy order so he doesn't to have reputation
+    pub fn is_full_privacy_order(&self) -> (bool, bool) {
+        let (mut full_privacy_buyer, mut full_privacy_seller) = (false, false);
+
+        // Find full privacy users in this trade
+        if self.master_buyer_pubkey == self.buyer_pubkey {
+            full_privacy_buyer = true;
+        }
+        if self.master_seller_pubkey == self.seller_pubkey {
+            full_privacy_seller = true;
+        }
+
+        (full_privacy_buyer, full_privacy_seller)
+    }
     /// Setup the dispute status
     ///
     /// If the pubkey is the buyer, set the buyer dispute to true

--- a/src/order.rs
+++ b/src/order.rs
@@ -345,10 +345,17 @@ impl Order {
         let (mut full_privacy_buyer, mut full_privacy_seller) = (false, false);
 
         // Find full privacy users in this trade
-        if self.master_buyer_pubkey == self.buyer_pubkey {
+        if self.buyer_pubkey.is_some()
+            && self.master_buyer_pubkey.is_some()
+            && self.master_buyer_pubkey == self.buyer_pubkey
+        {
             full_privacy_buyer = true;
         }
-        if self.master_seller_pubkey == self.seller_pubkey {
+
+        if self.seller_pubkey.is_some()
+            && self.master_seller_pubkey.is_some()
+            && self.master_seller_pubkey == self.seller_pubkey
+        {
             full_privacy_seller = true;
         }
 


### PR DESCRIPTION
@grunch @Catrya ,

I moved the check for `full privacy orders` in `mostro-core` to use it directly as order method and improved `SolverDisputeInfo` to have optional fields in case of full privacy orders.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced how dispute information is presented by grouping key user details such as ratings, reviews, and operational periods with integrated privacy handling.
  - Introduced a new check on orders to clearly indicate full privacy status for both buyers and sellers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->