### PR TITLE
Modified Peer payload to send taker infos about maker

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,7 @@ mod test {
         let uuid = uuid!("308e1272-d5f4-47e6-bd97-3504baea9c23");
         let peer = Peer::new(
             "npub1testjsf0runcqdht5apkfcalajxkf8txdxqqk5kgm0agc38ke4vsfsgzf8".to_string(),
+            None,
         );
         let payload = Payload::Peer(peer);
         let test_message = Message::Order(MessageKind::new(

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,4 +1,5 @@
 use crate::dispute::SolverDisputeInfo;
+use crate::dispute::UserDisputeInfo;
 use crate::error::ServiceError;
 use crate::PROTOCOL_VER;
 use crate::{error::CantDoReason, order::SmallOrder};
@@ -21,11 +22,12 @@ pub const MIN_RATING: u8 = 1;
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Peer {
     pub pubkey: String,
+    pub reputation: Option<UserDisputeInfo>,
 }
 
 impl Peer {
-    pub fn new(pubkey: String) -> Self {
-        Self { pubkey }
+    pub fn new(pubkey: String, reputation: Option<UserDisputeInfo>) -> Self {
+        Self { pubkey, reputation }
     }
 
     pub fn from_json(json: &str) -> Result<Self> {


### PR DESCRIPTION
@grunch @Catrya 

this is another update on `mostro-core`.

I added an optional field in Peer payload to inform maker about taker reputation, as said if it's a privacy user all values will be 0.

```Rust
pub struct Peer {
    pub pubkey: String,
    pub reputation: Option<UserDisputeInfo>,
}
```

Let me know if you like it @grunch ...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced peer profiles now support optional reputation details to provide additional context during dispute resolution.
- **Bug Fixes**
  - Improved unit tests for the `Peer` struct to ensure proper functionality with and without the new reputation field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->