### PR TITLE
Prelude.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mostro-core"
-version = "0.6.38"
+version = "0.6.39"
 edition = "2021"
 license = "MIT"
 authors = ["Francisco Calderón <negrunch@grunch.dev>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,13 +2,9 @@ pub mod dispute;
 pub mod error;
 pub mod message;
 pub mod order;
+pub mod prelude;
 pub mod rating;
 pub mod user;
-
-/// All events broadcasted by Mostro daemon are Parameterized Replaceable Events
-/// and the event kind must be between 30000 and 39999
-pub const NOSTR_REPLACEABLE_EVENT_KIND: u16 = 38383;
-pub const PROTOCOL_VER: u8 = 1;
 
 #[cfg(test)]
 mod test {

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,7 +1,6 @@
 use crate::dispute::SolverDisputeInfo;
 use crate::error::ServiceError;
 use crate::user::UserInfo;
-use crate::PROTOCOL_VER;
 use crate::{error::CantDoReason, order::SmallOrder};
 use anyhow::Result;
 use bitcoin::hashes::sha256::Hash as Sha256Hash;
@@ -17,6 +16,11 @@ use uuid::Uuid;
 pub const MAX_RATING: u8 = 5;
 // Min rating
 pub const MIN_RATING: u8 = 1;
+
+/// All events broadcasted by Mostro daemon are Parameterized Replaceable Events
+/// and the event kind must be between 30000 and 39999
+pub const NOSTR_REPLACEABLE_EVENT_KIND: u16 = 38383;
+pub const PROTOCOL_VER: u8 = 1;
 
 /// One party of the trade
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -429,8 +433,8 @@ impl MessageKind {
 
 #[cfg(test)]
 mod test {
-    use crate::user::UserInfo;
     use crate::message::{Action, Message, MessageKind, Payload, Peer};
+    use crate::user::UserInfo;
     use nostr_sdk::Keys;
     use uuid::uuid;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,12 @@
+/// This module re-exports commonly used types and traits for convenience.
+/// It allows users to import everything they need from a single module
+pub use crate::error::{CantDoReason, MostroError, ServiceError};
+pub use crate::dispute::{Dispute, SolverDisputeInfo, Status as DisputeStatus};
+pub use crate::message::{
+    Action, Message, MessageKind, Payload, Peer, MAX_RATING, MIN_RATING,
+    NOSTR_REPLACEABLE_EVENT_KIND,
+};
+pub use crate::order::{Kind, Order, SmallOrder, Status};
+pub use crate::rating::Rating;
+pub use crate::user::{User, UserInfo};
+pub use MostroError::*;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,8 @@
-/// This module re-exports commonly used types and traits for convenience.
-/// It allows users to import everything they need from a single module
+// This module re-exports commonly used types and traits for convenience.
+// It allows users to import everything they need from a single module
+// 
+//! Prelude
+
 pub use crate::error::{CantDoReason, MostroError, ServiceError};
 pub use crate::dispute::{Dispute, SolverDisputeInfo, Status as DisputeStatus};
 pub use crate::message::{


### PR DESCRIPTION
@grunch ,

this is mostro-core with `prelude.rs` so now all symbols in prelude are re-exported and we can remove some bloat import in many files in `mostrod`, I have yet a branch of mostrod with the clean done. Will push it.