### PR TITLE
Small update for complete prelude file introduction

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -33,12 +33,12 @@ impl Peer {
         Self { pubkey, reputation }
     }
 
-    pub fn from_json(json: &str) -> Result<Self> {
-        Ok(serde_json::from_str(json)?)
+    pub fn from_json(json: &str) -> Result<Self, ServiceError> {
+        serde_json::from_str(json).map_err(|_| ServiceError::MessageSerializationError)
     }
 
-    pub fn as_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self)?)
+    pub fn as_json(&self) -> Result<String, ServiceError> {
+        serde_json::to_string(&self).map_err(|_| ServiceError::MessageSerializationError)
     }
 }
 
@@ -151,13 +151,13 @@ impl Message {
     }
 
     /// Get message from json string
-    pub fn from_json(json: &str) -> Result<Self> {
-        Ok(serde_json::from_str(json)?)
+    pub fn from_json(json: &str) -> Result<Self, ServiceError> {
+        serde_json::from_str(json).map_err(|_| ServiceError::MessageSerializationError)
     }
 
     /// Get message as json string
-    pub fn as_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self)?)
+    pub fn as_json(&self) -> Result<String, ServiceError> {
+        serde_json::to_string(&self).map_err(|_| ServiceError::MessageSerializationError)
     }
 
     // Get inner message kind
@@ -284,12 +284,12 @@ impl MessageKind {
         }
     }
     /// Get message from json string
-    pub fn from_json(json: &str) -> Result<Self> {
-        Ok(serde_json::from_str(json)?)
+    pub fn from_json(json: &str) -> Result<Self, ServiceError> {
+        serde_json::from_str(json).map_err(|_| ServiceError::MessageSerializationError)
     }
     /// Get message as json string
-    pub fn as_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self)?)
+    pub fn as_json(&self) -> Result<String, ServiceError> {
+        serde_json::to_string(&self).map_err(|_| ServiceError::MessageSerializationError)
     }
 
     // Get action from the inner message

--- a/src/rating.rs
+++ b/src/rating.rs
@@ -31,13 +31,13 @@ impl Rating {
     }
 
     /// New order from json string
-    pub fn from_json(json: &str) -> Result<Self> {
-        Ok(serde_json::from_str(json)?)
+    pub fn from_json(json: &str) -> Result<Self, ServiceError> {
+        serde_json::from_str(json).map_err(|_| ServiceError::MessageSerializationError)
     }
 
     /// Get order as json string
-    pub fn as_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self)?)
+    pub fn as_json(&self) -> Result<String, ServiceError> {
+        serde_json::to_string(&self).map_err(|_| ServiceError::MessageSerializationError)
     }
 
     /// Transform Rating struct to tuple vector to easily interact with Nostr


### PR DESCRIPTION
@grunch ,

some errors were still managed without explicit errors ( due to anyhow management previously ) causing Mostrod having errors during build. 
Now all errors are managed with our `Enums`.

Nothing big here, take a look and merge.

Then we can bump version ( 6.39 ) and publish it on `crates.io`. Then we can merge mostrod [pull request](https://github.com/MostroP2P/mostro/pull/483) related to prelude.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for message and rating serialization and deserialization, providing clearer and more consistent error messages when processing JSON data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->