### PR TITLE
Cargo release improved

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ sign-tag = true
 allow-branch = ["main"]
 # Git cliff to generate the changelog
 pre-release-hook = [
-  "sh", "-c", "git cliff --unreleased --github-repo MostroP2P/mostro-core -o CHANGELOG.md --tag {{version}} && if [ \"$DRY_RUN\" != \"true\" ]; then git add CHANGELOG.md && git commit -m \"Update CHANGELOG for version {{version}}\"; else echo \"DRY RUN: Skip git add and commit\"; fi"
+  "sh", "-c", "git cliff --unreleased --github-repo MostroP2P/mostro-core -o CHANGELOG.md --tag {{version}} && if [ \"$DRY_RUN\" != \"true\" ]; then git diff --quiet CHANGELOG.md || cagit add CHANGELOG.md && git commit -m \"Update CHANGELOG for version {{version}}\"; else echo \"DRY RUN: Skip git add and commit\"; fi"
 ]
 [dependencies]
 chrono = "0.4.38"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,8 @@ sign-tag = true
 allow-branch = ["main"]
 # Git cliff to generate the changelog
 pre-release-hook = [
-  "sh", "-c", "git cliff --unreleased --github-repo MostroP2P/mostro-core -o CHANGELOG.md --tag {{version}} && git add CHANGELOG.md && git commit -m 'Update CHANGELOG for version {{version}}'"]
+  "sh", "-c", "git cliff --unreleased --github-repo MostroP2P/mostro-core -o CHANGELOG.md --tag {{version}} && [ \"$DRY_RUN\" != \"true\" ] && git add CHANGELOG.md && [ \"$DRY_RUN\" != \"true\" ] && git commit -m 'Update CHANGELOG for version {{version}}'"
+]
 [dependencies]
 chrono = "0.4.38"
 serde = { version = "1.0.149", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ sign-tag = true
 allow-branch = ["main"]
 # Git cliff to generate the changelog
 pre-release-hook = [
-  "sh", "-c", "git cliff --unreleased --github-repo MostroP2P/mostro-core -o CHANGELOG.md --tag {{version}} && [ \"$DRY_RUN\" != \"true\" ] && git add CHANGELOG.md && [ \"$DRY_RUN\" != \"true\" ] && git commit -m 'Update CHANGELOG for version {{version}}'"
+  "sh", "-c", "git cliff --unreleased --github-repo MostroP2P/mostro-core -o CHANGELOG.md --tag {{version}} && if [ \"$DRY_RUN\" != \"true\" ]; then git add CHANGELOG.md && git commit -m \"Update CHANGELOG for version {{version}}\"; else echo \"DRY RUN: Skip git add and commit\"; fi"
 ]
 [dependencies]
 chrono = "0.4.38"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Mostro Core is a Rust-based library that provides peer-to-peer functionality for
 
 - Rust 1.86.0 or later
 - Cargo (Rust's package manager)
+- [cargo-release](https://crates.io/crates/cargo-release) for releasing new versions
+- [git-cliff](https://crates.io/crates/git-cliff) for generating the changelog
 
 ## Features
 


### PR DESCRIPTION
@grunch 

small improvement on `cargo-release` now if i removed the case of multiple commit with same name and CHANGELOG.md, file is now committed only when `--execute` is used and in dry run file is not staged and not committed.

```Bash
# Git cliff to generate the changelog
pre-release-hook = [
  "sh", "-c", "git cliff --unreleased --github-repo MostroP2P/mostro-core -o CHANGELOG.md --tag {{version}} && if [ \"$DRY_RUN\" != \"true\" ]; then git add CHANGELOG.md && git commit -m \"Update CHANGELOG for version {{version}}\"; else echo \"DRY RUN: Skip git add and commit\"; fi"
]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated release process to support a dry-run mode, allowing changelog generation without committing changes when enabled.
  - Added new development tools to the requirements documentation for version releasing and changelog generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->