### PR TITLE
add payload info to payment-failed message

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -6,7 +6,7 @@
 pub use crate::crypto::*;
 pub use crate::dispute::{Dispute, SolverDisputeInfo, Status as DisputeStatus};
 pub use crate::error::{CantDoReason, MostroError, ServiceError};
-pub use crate::message::{Action, Message, MessageKind, Payload, Peer};
+pub use crate::message::{Action, Message, MessageKind, Payload, PaymentFailedInfo, Peer};
 pub use crate::order::{Kind, Order, SmallOrder, Status};
 pub use crate::rating::Rating;
 pub use crate::user::{User, UserInfo};


### PR DESCRIPTION
to fix https://github.com/MostroP2P/mostro/issues/474
Show information about retries for failed payments