### PR TITLE
Revert "Added an optional Peer in payloads"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,28 +34,25 @@ mod test {
     fn test_order_message() {
         let uuid = uuid!("308e1272-d5f4-47e6-bd97-3504baea9c23");
         let payment_methods = "SEPA,Bank transfer".to_string();
-        let payload = Payload::Order(
-            SmallOrder::new(
-                Some(uuid),
-                Some(Kind::Sell),
-                Some(Status::Pending),
-                100,
-                "eur".to_string(),
-                None,
-                None,
-                100,
-                payment_methods,
-                1,
-                None,
-                None,
-                None,
-                Some(1627371434),
-                None,
-                None,
-                None,
-            ),
+        let payload = Payload::Order(SmallOrder::new(
+            Some(uuid),
+            Some(Kind::Sell),
+            Some(Status::Pending),
+            100,
+            "eur".to_string(),
             None,
-        );
+            None,
+            100,
+            payment_methods,
+            1,
+            None,
+            None,
+            None,
+            Some(1627371434),
+            None,
+            None,
+            None,
+        ));
 
         let test_message = Message::Order(MessageKind::new(
             Some(uuid),
@@ -65,7 +62,7 @@ mod test {
             Some(payload),
         ));
         let test_message_json = test_message.as_json().unwrap();
-        let sample_message = r#"{"order":{"version":1,"id":"308e1272-d5f4-47e6-bd97-3504baea9c23","request_id":1,"trade_index":2,"action":"new-order","payload":{"order":[{"id":"308e1272-d5f4-47e6-bd97-3504baea9c23","kind":"sell","status":"pending","amount":100,"fiat_code":"eur","fiat_amount":100,"payment_method":"SEPA,Bank transfer","premium":1,"created_at":1627371434},null]}}}"#;
+        let sample_message = r#"{"order":{"version":1,"id":"308e1272-d5f4-47e6-bd97-3504baea9c23","request_id":1,"trade_index":2,"action":"new-order","payload":{"order":{"id":"308e1272-d5f4-47e6-bd97-3504baea9c23","kind":"sell","status":"pending","amount":100,"fiat_code":"eur","fiat_amount":100,"payment_method":"SEPA,Bank transfer","premium":1,"created_at":1627371434}}}}"#;
         let message = Message::from_json(sample_message).unwrap();
         assert!(message.verify());
         let message_json = message.as_json().unwrap();
@@ -102,10 +99,9 @@ mod test {
                 )),
                 "lnbcrt78510n1pj59wmepp50677g8tffdqa2p8882y0x6newny5vtz0hjuyngdwv226nanv4uzsdqqcqzzsxqyz5vqsp5skn973360gp4yhlpmefwvul5hs58lkkl3u3ujvt57elmp4zugp4q9qyyssqw4nzlr72w28k4waycf27qvgzc9sp79sqlw83j56txltz4va44j7jda23ydcujj9y5k6k0rn5ms84w8wmcmcyk5g3mhpqepf7envhdccp72nz6e".to_string(),
                 None,
-                None,
             )),
         ));
-        let sample_message = r#"{"order":{"version":1,"id":"308e1272-d5f4-47e6-bd97-3504baea9c23","request_id":1,"trade_index":3,"action":"pay-invoice","payload":{"payment_request":[{"id":"308e1272-d5f4-47e6-bd97-3504baea9c23","kind":"sell","status":"waiting-payment","amount":100,"fiat_code":"eur","fiat_amount":100,"payment_method":"Face to face","premium":1,"created_at":1627371434},"lnbcrt78510n1pj59wmepp50677g8tffdqa2p8882y0x6newny5vtz0hjuyngdwv226nanv4uzsdqqcqzzsxqyz5vqsp5skn973360gp4yhlpmefwvul5hs58lkkl3u3ujvt57elmp4zugp4q9qyyssqw4nzlr72w28k4waycf27qvgzc9sp79sqlw83j56txltz4va44j7jda23ydcujj9y5k6k0rn5ms84w8wmcmcyk5g3mhpqepf7envhdccp72nz6e",null,null]}}}"#;
+        let sample_message = r#"{"order":{"version":1,"id":"308e1272-d5f4-47e6-bd97-3504baea9c23","request_id":1,"trade_index":3,"action":"pay-invoice","payload":{"payment_request":[{"id":"308e1272-d5f4-47e6-bd97-3504baea9c23","kind":"sell","status":"waiting-payment","amount":100,"fiat_code":"eur","fiat_amount":100,"payment_method":"Face to face","premium":1,"created_at":1627371434},"lnbcrt78510n1pj59wmepp50677g8tffdqa2p8882y0x6newny5vtz0hjuyngdwv226nanv4uzsdqqcqzzsxqyz5vqsp5skn973360gp4yhlpmefwvul5hs58lkkl3u3ujvt57elmp4zugp4q9qyyssqw4nzlr72w28k4waycf27qvgzc9sp79sqlw83j56txltz4va44j7jda23ydcujj9y5k6k0rn5ms84w8wmcmcyk5g3mhpqepf7envhdccp72nz6e",null]}}}"#;
         let message = Message::from_json(sample_message).unwrap();
         assert!(message.verify());
         let message_json = message.as_json().unwrap();

--- a/src/message.rs
+++ b/src/message.rs
@@ -239,9 +239,9 @@ pub struct PaymentFailedInfo {
 #[serde(rename_all = "snake_case")]
 pub enum Payload {
     /// Order
-    Order(SmallOrder, Option<Peer>),
+    Order(SmallOrder),
     /// Payment request
-    PaymentRequest(Option<SmallOrder>, String, Option<Amount>, Option<Peer>),
+    PaymentRequest(Option<SmallOrder>, String, Option<Amount>),
     /// Use to send a message to another user
     TextMessage(String),
     /// Peer information
@@ -318,12 +318,12 @@ impl MessageKind {
     /// Verify if is valid message
     pub fn verify(&self) -> bool {
         match &self.action {
-            Action::NewOrder => matches!(&self.payload, Some(Payload::Order(_, _))),
+            Action::NewOrder => matches!(&self.payload, Some(Payload::Order(_))),
             Action::PayInvoice | Action::AddInvoice => {
                 if self.id.is_none() {
                     return false;
                 }
-                matches!(&self.payload, Some(Payload::PaymentRequest(_, _, _, _)))
+                matches!(&self.payload, Some(Payload::PaymentRequest(_, _, _)))
             }
             Action::TakeSell
             | Action::TakeBuy
@@ -384,7 +384,7 @@ impl MessageKind {
             return None;
         }
         match &self.payload {
-            Some(Payload::Order(o, _)) => Some(o),
+            Some(Payload::Order(o)) => Some(o),
             _ => None,
         }
     }
@@ -397,8 +397,8 @@ impl MessageKind {
             return None;
         }
         match &self.payload {
-            Some(Payload::PaymentRequest(_, pr, _, _)) => Some(pr.to_owned()),
-            Some(Payload::Order(ord, _)) => ord.buyer_invoice.to_owned(),
+            Some(Payload::PaymentRequest(_, pr, _)) => Some(pr.to_owned()),
+            Some(Payload::Order(ord)) => ord.buyer_invoice.to_owned(),
             _ => None,
         }
     }
@@ -408,7 +408,7 @@ impl MessageKind {
             return None;
         }
         match &self.payload {
-            Some(Payload::PaymentRequest(_, _, amount, _)) => *amount,
+            Some(Payload::PaymentRequest(_, _, amount)) => *amount,
             Some(Payload::Amount(amount)) => Some(*amount),
             _ => None,
         }


### PR DESCRIPTION
Reverts MostroP2P/mostro-core#112

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified the structure of order and payment request messages, removing unnecessary fields for a cleaner experience when handling these payloads.

* **Tests**
  * Updated test cases to reflect the streamlined message format, ensuring consistency with the new structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->