### PR TITLE
Add DisputeTakenByAdmin error type for issue #302

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -42,6 +42,8 @@ pub enum CantDoReason {
     OutOfRangeSatsAmount,
     /// For users trying to do actions on dispute that are not theirs
     IsNotYourDispute,
+    /// For solvers when admin has taken over their dispute
+    DisputeTakenByAdmin,
     /// For users trying to create a dispute on an order that is not in dispute
     DisputeCreationError,
     /// Generic not found


### PR DESCRIPTION
## Summary
- Add new `CantDoReason::DisputeTakenByAdmin` error variant
- Improves error messaging when admin takes over dispute from solver
- Addresses MostroP2P/mostro#302

## Changes
- Added `DisputeTakenByAdmin` to `CantDoReason` enum in `src/error.rs`
- Provides semantic error type for admin dispute takeover scenarios

## Context
When a solver takes a dispute and then an admin takes it over, the solver currently gets a generic "Dispute not taken by you" error when trying to resolve it. This new error type enables more specific messaging to inform solvers that an admin has taken over their dispute.

## Related
- **Depends on**: This change enables MostroP2P/mostro#302 implementation
- **Follow-up**: mostro repo PR will use this new error type