### PR TITLE
Add InvalidFiatCurrency error in CantDo 

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -54,6 +54,8 @@ pub enum CantDoReason {
     InvalidAction,
     /// Pending order exists
     PendingOrderExists,
+    /// Invalid fiat currency
+    InvalidFiatCurrency,
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,7 @@ mod test {
             CantDoReason::OutOfRangeSatsAmount,
             CantDoReason::IsNotYourDispute,
             CantDoReason::NotFound,
+            CantDoReason::InvalidFiatCurrency,
         ];
 
         for reason in reasons {

--- a/src/order.rs
+++ b/src/order.rs
@@ -512,7 +512,7 @@ impl SmallOrder {
     /// Check if the fiat currency is accepted
     pub fn check_fiat_currency(
         &self,
-        fiat_currencies_accepted: &Vec<String>,
+        fiat_currencies_accepted: Vec<String>,
     ) -> Result<(), CantDoReason> {
         if !fiat_currencies_accepted.contains(&self.fiat_code)
             && !fiat_currencies_accepted.is_empty()

--- a/src/order.rs
+++ b/src/order.rs
@@ -512,7 +512,7 @@ impl SmallOrder {
     /// Check if the fiat currency is accepted
     pub fn check_fiat_currency(
         &self,
-        fiat_currencies_accepted: Vec<String>,
+        fiat_currencies_accepted: &[String],
     ) -> Result<(), CantDoReason> {
         if !fiat_currencies_accepted.contains(&self.fiat_code)
             && !fiat_currencies_accepted.is_empty()

--- a/src/order.rs
+++ b/src/order.rs
@@ -508,6 +508,19 @@ impl SmallOrder {
         }
         Ok(())
     }
+
+    /// Check if the fiat currency is accepted
+    pub fn check_fiat_currency(
+        &self,
+        fiat_currencies_accepted: &Vec<String>,
+    ) -> Result<(), CantDoReason> {
+        if !fiat_currencies_accepted.contains(&self.fiat_code)
+            && !fiat_currencies_accepted.is_empty()
+        {
+            return Err(CantDoReason::InvalidFiatCurrency);
+        }
+        Ok(())
+    }
 }
 
 impl From<Order> for SmallOrder {


### PR DESCRIPTION
@grunch 

small pr to add a meaningful error when a wrong currency is used in a new order.

I have ready also `mostrod` side of this feature, just create ( if this PR looks good ) the new version of mostro core and I will proceed with PR on mostrod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit fiat-currency validation during order processing to detect unsupported currencies earlier.
  * Introduced a distinct error state for invalid fiat currencies to allow clearer handling.

* **Bug Fixes**
  * Improved user-facing messaging for unsupported fiat selections for clearer feedback.
  * Prevents proceeding with unrecognized fiat currencies, reducing failed attempts and checkout confusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->