### PR TITLE
Add SynchUserTradeIndex Action

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -78,6 +78,7 @@ pub enum Action {
     SendDm,
     TradePubkey,
     RestoreSession,
+    SynchUserTradeIndex,
     Orders,
 }
 
@@ -444,6 +445,7 @@ impl MessageKind {
             | Action::AdminAddSolver
             | Action::SendDm
             | Action::TradePubkey
+            | Action::SynchUserTradeIndex
             | Action::Canceled => {
                 if self.id.is_none() {
                     return false;


### PR DESCRIPTION
@grunch ,

during my tests with new cli I prepared the basics to have the synch of last trade index of the users triggerable from client.

Mostro core has a new action:

`SynchUserTradeIndex`