### PR TITLE
Aligned cargo release and gh actions to mostrod process

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,6 +70,27 @@ jobs:
       - name: Build release
         run: cargo build --release
 
+  # Publish to crates.io (only if all builds succeed)
+  # This job will only run if both test and build jobs succeed.
+  # With fail-fast: false, the build job fails if ANY matrix build fails,
+  # ensuring all artifacts are built before publishing.
+  publish:
+    runs-on: ubuntu-latest
+    needs: [test, build]
+    if: success()
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with: { cache-on-failure: true }
+      - name: Publish to crates.io
+        run: cargo publish --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+
   # Create release
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,8 +72,6 @@ jobs:
 
   # Publish to crates.io (only if all builds succeed)
   # This job will only run if both test and build jobs succeed.
-  # With fail-fast: false, the build job fails if ANY matrix build fails,
-  # ensuring all artifacts are built before publishing.
   publish:
     runs-on: ubuntu-latest
     needs: [test, build]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -92,7 +92,7 @@ jobs:
   # Create release
   release:
     runs-on: ubuntu-latest
-    needs: [changelog, build]
+    needs: [changelog, build, publish]
     permissions:
       contents: write
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ allow-branch = ["main"]
 pre-release-hook = [
   "sh",
   "-c",
-  "cargo fmt --all && cargo clippy --all-targets --all-features -- -D warnings && if [ -n \"${GITHUB_TOKEN:-}\" ]; then GITHUB_TOKEN=\"$GITHUB_TOKEN\" git cliff --unreleased --github-repo MostroP2P/mostro-core -o CHANGELOG.md --tag {{version}}; else git cliff --unreleased -o CHANGELOG.md --tag {{version}}; fi && if [ \"$DRY_RUN\" != \"true\" ]; then git diff --quiet CHANGELOG.md || git add CHANGELOG.md && git commit -m \"Update CHANGELOG for version {{version}}\"; else echo \"DRY RUN: Skip git add and commit\"; fi",
+  "cargo fmt --all && cargo clippy --all-targets --all-features -- -D warnings && if [ -n \"${GITHUB_TOKEN:-}\" ]; then GITHUB_TOKEN=\"$GITHUB_TOKEN\" git cliff --unreleased --github-repo MostroP2P/mostro-core -o CHANGELOG.md --tag {{version}}; else git cliff --unreleased -o CHANGELOG.md --tag {{version}}; fi && if [ \"$DRY_RUN\" != \"true\" ]; then git diff --quiet CHANGELOG.md || { git add CHANGELOG.md && git commit -m \"Update CHANGELOG for version {{version}}\"; }; else echo \"DRY RUN: Skip git add and commit\"; fi",
 ]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mostro-core"
-version = "0.6.56"
+version = "0.6.57"
 edition = "2021"
 license = "MIT"
 authors = ["Francisco Calderón <negrunch@grunch.dev>"]
@@ -13,7 +13,7 @@ crate-type = ["cdylib", "lib"]
 
 [package.metadata.release]
 # (Default: true) Set to false to prevent automatically running `cargo publish`.
-publish = true
+publish = false
 # (Default: true) Set to false to prevent automatically pushing commits and tags to the Git remote.
 push = true
 # (Default: true) Run `cargo test` before release? Highly recommended.
@@ -30,7 +30,7 @@ allow-branch = ["main"]
 pre-release-hook = [
   "sh",
   "-c",
-  "rm -f CHANGELOG.md && GITHUB_TOKEN=\"${GITHUB_TOKEN:-}\" git cliff --unreleased --github-repo MostroP2P/mostro-core -o CHANGELOG.md --tag {{version}} && if [ \"$DRY_RUN\" = \"true\" ]; then echo \"DRY RUN: Skip add/commit\"; else (git diff --quiet CHANGELOG.md || git add CHANGELOG.md && git commit -m \"Update CHANGELOG for version {{version}}\"); fi",
+  "cargo fmt --all && cargo clippy --all-targets --all-features -- -D warnings && if [ -n \"${GITHUB_TOKEN:-}\" ]; then GITHUB_TOKEN=\"$GITHUB_TOKEN\" git cliff --unreleased --github-repo MostroP2P/mostro-core -o CHANGELOG.md --tag {{version}}; else git cliff --unreleased -o CHANGELOG.md --tag {{version}}; fi && if [ \"$DRY_RUN\" != \"true\" ]; then git diff --quiet CHANGELOG.md || git add CHANGELOG.md && git commit -m \"Update CHANGELOG for version {{version}}\"; else echo \"DRY RUN: Skip git add and commit\"; fi",
 ]
 
 [dependencies]


### PR DESCRIPTION
Now i managed to:

- change  pre hook command for cargo release
- crates.io updated only if test and build are ok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.6.57.
  * CI workflow updated to add an automated publish step that runs after tests and build; release creation now waits for publish to succeed.
  * Release configuration adjusted to disable automatic publishing via metadata and to improve pre-release hooks for formatting, linting, changelog handling, and safer commit behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->