### PR TITLE
fix: include created_at and expires_at in SmallOrder conversion

### DIFF
--- a/src/order.rs
+++ b/src/order.rs
@@ -559,8 +559,8 @@ impl From<Order> for SmallOrder {
             buyer_trade_pubkey,
             seller_trade_pubkey,
             buyer_invoice,
-            created_at: None,
-            expires_at: None,
+            created_at: Some(order.created_at),
+            expires_at: Some(order.expires_at),
         }
     }
 }


### PR DESCRIPTION
fix #126 
Include created_at and expires_at when converting Order to SmallOrder to ensure makers receive complete order information in direct messages when orders are republished.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SmallOrder objects now correctly populate creation and expiration timestamp information when derived from Order objects, ensuring data consistency and complete information preservation during conversions. This improves data accuracy while maintaining backward compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->