### PR TITLE
BREAKING CHANGE: Add distinct Nostr event kinds for orders, ratings, …

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -21,7 +21,9 @@ pub use MostroError::*;
 pub const MAX_RATING: u8 = 5;
 // Min rating for a user
 pub const MIN_RATING: u8 = 1;
-// All events broadcasted by Mostro daemon are Parameterized Replaceable Events
-// and the event kind must be between 30000 and 39999
-pub const NOSTR_REPLACEABLE_EVENT_KIND: u16 = 38383;
+// Addressable event kind must be between 30000 and 39999 (NIP-1)
+pub const NOSTR_ORDER_EVENT_KIND: u16 = 38383;
+pub const NOSTR_RATING_EVENT_KIND: u16 = 38384;
+pub const NOSTR_INFO_EVENT_KIND: u16 = 38385;
+pub const NOSTR_DISPUTE_EVENT_KIND: u16 = 38386;
 pub(crate) const PROTOCOL_VER: u8 = 1;


### PR DESCRIPTION
…info, and disputes

- Rename NOSTR_REPLACEABLE_EVENT_KIND to NOSTR_ORDER_EVENT_KIND (38383)
- Add NOSTR_RATING_EVENT_KIND (38384) for user ratings
- Add NOSTR_INFO_EVENT_KIND (38385) for info events
- Add NOSTR_DISPUTE_EVENT_KIND (38386) for dispute events
- Update comment to properly reference NIP-1 addressable events

This change requires updating all code that previously used NOSTR_REPLACEABLE_EVENT_KIND to use the new specific constants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Event kind constants have been updated. A single generic event kind constant has been replaced with four specific constants for orders, ratings, information, and disputes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->