### PR TITLE
Adds solver public key to dispute restore data

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -832,11 +832,20 @@ mod test {
                     session_info.restore_disputes[0].initiator,
                     Some(crate::message::DisputeInitiator::Buyer)
                 );
+                assert!(session_info.restore_disputes[0].solver_pubkey.is_none());
                 assert_eq!(session_info.restore_disputes[1].initiator, None);
+                assert_eq!(
+                    session_info.restore_disputes[1].solver_pubkey,
+                    Some(
+                        "aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344"
+                            .to_string()
+                    )
+                );
                 assert_eq!(
                     session_info.restore_disputes[2].initiator,
                     Some(crate::message::DisputeInitiator::Seller)
                 );
+                assert!(session_info.restore_disputes[2].solver_pubkey.is_none());
             } else {
                 panic!("Expected RestoreData payload");
             }
@@ -997,6 +1006,7 @@ mod test {
         assert_eq!(deserialized.trade_index_seller, helper.trade_index_seller);
         assert_eq!(deserialized.buyer_dispute, helper.buyer_dispute);
         assert_eq!(deserialized.seller_dispute, helper.seller_dispute);
+        assert_eq!(deserialized.solver_pubkey, helper.solver_pubkey);
 
         let helper_seller_dispute = RestoredDisputeHelper {
             dispute_id: uuid!("608e1272-d5f4-47e6-bd97-3504baea9c26"),
@@ -1032,5 +1042,9 @@ mod test {
         assert_eq!(deserialized_seller.trade_index_seller, None);
         assert!(!deserialized_seller.buyer_dispute);
         assert!(deserialized_seller.seller_dispute);
+        assert_eq!(
+            deserialized_seller.solver_pubkey,
+            helper_seller_dispute.solver_pubkey
+        );
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -281,6 +281,8 @@ pub struct RestoredDisputeHelper {
     /// Indicates whether the seller has initiated a dispute for this order.
     /// Used in conjunction with `buyer_dispute` to derive the `initiator` field in `RestoredDisputesInfo`.
     pub seller_dispute: bool,
+    /// Public key of the solver assigned to the dispute, None if no solver has taken it.
+    pub solver_pubkey: Option<String>,
 }
 
 /// Information about the order to be restored in the new client
@@ -319,6 +321,8 @@ pub struct RestoredDisputesInfo {
     pub status: String,
     /// Who initiated the dispute: Buyer, Seller, or null if unknown
     pub initiator: Option<DisputeInitiator>,
+    /// Public key of the solver assigned to the dispute, None if no solver has taken it yet
+    pub solver_pubkey: Option<String>,
 }
 
 /// Restore session user info
@@ -778,6 +782,7 @@ mod test {
                 trade_index: 1,
                 status: "initiated".to_string(),
                 initiator: Some(crate::message::DisputeInitiator::Buyer),
+                solver_pubkey: None,
             },
             crate::message::RestoredDisputesInfo {
                 dispute_id: uuid!("608e1272-d5f4-47e6-bd97-3504baea9c26"),
@@ -785,6 +790,9 @@ mod test {
                 trade_index: 2,
                 status: "in-progress".to_string(),
                 initiator: None,
+                solver_pubkey: Some(
+                    "aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344".to_string(),
+                ),
             },
             crate::message::RestoredDisputesInfo {
                 dispute_id: uuid!("708e1272-d5f4-47e6-bd97-3504baea9c27"),
@@ -792,6 +800,7 @@ mod test {
                 trade_index: 3,
                 status: "initiated".to_string(),
                 initiator: Some(crate::message::DisputeInitiator::Seller),
+                solver_pubkey: None,
             },
         ];
 
@@ -970,6 +979,7 @@ mod test {
             trade_index_seller: Some(2),
             buyer_dispute: true,
             seller_dispute: false,
+            solver_pubkey: None,
         };
 
         let json = serde_json::to_string(&helper).unwrap();
@@ -998,6 +1008,9 @@ mod test {
             trade_index_seller: None,
             buyer_dispute: false,
             seller_dispute: true,
+            solver_pubkey: Some(
+                "aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344".to_string(),
+            ),
         };
 
         let json_seller = serde_json::to_string(&helper_seller_dispute).unwrap();


### PR DESCRIPTION
This PR adds `solver_pubkey` as an optional field to `RestoredDisputesInfo`  and `RestoredDisputeHelper`.

When a client restores its session after losing state, it needs to  re-establish encrypted communication channels with all relevant parties. 

For active disputes, the client must open an encrypted chat with the  assigned solver. The client needs the solver's pubkey  at restore time.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional solver identification field to restored dispute/session data, allowing tracking of an assigned solver when present.

* **Tests**
  * Updated restore-session/dispute fixtures and JSON serialization tests to verify the solver field is preserved through round-trip operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->