### PR TITLE
feat: add NIP-59 GiftWrap transport module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,10 +55,13 @@ sqlx-crud = { version = "0.4.0", features = [
   "runtime-tokio-rustls",
 ], optional = true }
 wasm-bindgen = { version = "0.2.92", optional = true }
-nostr-sdk = "0.43.0"
+nostr-sdk = { version = "0.44.1", features = ["nip44", "nip59"] }
 bitcoin = "0.32.7"
 
 [features]
 default = ["wasm"]
 wasm = ["dep:wasm-bindgen"]
 sqlx = ["dep:wasm-bindgen", "dep:sqlx", "dep:sqlx-crud"]
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/docs/NIP59_TRANSPORT.md
+++ b/docs/NIP59_TRANSPORT.md
@@ -1,0 +1,305 @@
+# NIP-59 GiftWrap Transport
+
+Technical specification for `src/nip59.rs`, the module that wraps and
+unwraps Mostro messages for transport over Nostr using NIP-59
+(GiftWrap).
+
+## Goals
+
+- Centralize the wrap / unwrap pipeline so clients do not reimplement
+  NIP-59 glue.
+- Cryptographically bind every message to the sender's trade identity
+  via an inner tuple signature.
+- Preserve NIP-59 metadata hygiene: CSPRNG-based timestamp jitter,
+  ephemeral outer signer, optional expiration, optional PoW.
+- Keep a strict error contract that distinguishes "not addressed to
+  me" from "protocol violation".
+
+## Non-goals
+
+The module deliberately does **not** manage relays, subscriptions,
+waiters, deduplication, persistence or retries. It returns an `Event`
+ready to publish and a decoder for incoming events — the caller owns
+transport policy.
+
+## Message pipeline
+
+```text
+Message
+  │
+  ▼
+JSON( (Message, Option<Signature>) )          ← inner tuple
+  │                         │
+  │                         └── signature over message JSON, produced
+  │                             with trade_keys (present when
+  │                             WrapOptions.signed == true)
+  ▼
+Rumor (UnsignedEvent, kind 1, author = trade_keys)
+  │
+  ▼
+Seal  (kind 13, signed by trade_keys, content = NIP-44(rumor))
+  │
+  ▼
+GiftWrap (kind 1059, signed by fresh ephemeral keys,
+          content = NIP-44(seal),
+          tags = [ ["p", receiver], optional ["expiration", ts] ],
+          optional PoW, randomized created_at)
+```
+
+`nostr-sdk` 0.44 enforces that the rumor author equals the seal signer
+(`nip59::Error::SenderMismatch`). Both layers are therefore signed with
+`trade_keys`; the outer GiftWrap is always signed with a freshly
+generated ephemeral keypair.
+
+## Public API
+
+### `WrapOptions`
+
+```rust
+pub struct WrapOptions {
+    pub pow: u8,                          // NIP-13 difficulty, outer layer only
+    pub expiration: Option<Timestamp>,    // NIP-40 tag on the GiftWrap
+    pub signed: bool,                     // inner tuple signature on/off
+}
+```
+
+`Default` yields `pow = 0`, `expiration = None`, `signed = true`.
+Traffic to a Mostro node always uses `signed = true`; the unsigned
+variant exists for flows where the caller intentionally forgoes
+identity binding.
+
+### `UnwrappedMessage`
+
+```rust
+pub struct UnwrappedMessage {
+    pub message: Message,              // decoded Mostro payload
+    pub signature: Option<Signature>,  // Some iff sender set signed = true
+    pub sender: PublicKey,             // rumor / seal author
+    pub created_at: Timestamp,         // rumor created_at (not the wrap's)
+}
+```
+
+`sender` is the trade pubkey of the sender. Because `nostr-sdk`
+rejects `SenderMismatch`, `sender` is also the pubkey that signed the
+seal, which is the same key that produced the inner tuple signature.
+
+### `wrap_message`
+
+```rust
+pub async fn wrap_message(
+    message: &Message,
+    trade_keys: &Keys,
+    receiver: PublicKey,
+    opts: WrapOptions,
+) -> Result<Event, MostroError>
+```
+
+Builds a publishable GiftWrap event. Steps:
+
+1. Serialize `message` to JSON.
+2. If `opts.signed`, sign the JSON with `trade_keys` and include the
+   signature in the inner tuple; else include `None`.
+3. Build the rumor as `EventBuilder::text_note(inner_json)` authored
+   by `trade_keys.public_key()`. **No PoW is mined on the rumor** —
+   it is encrypted inside the seal and never published alone.
+4. Seal via `EventBuilder::seal(trade_keys, &receiver, rumor)` and
+   sign with `trade_keys`.
+5. Encrypt the seal JSON with NIP-44 under a fresh ephemeral key for
+   `receiver`, attach `["p", receiver]` (mandatory) and optionally
+   `["expiration", ts]`, stamp `created_at =
+   Timestamp::tweaked(nip59::RANGE_RANDOM_TIMESTAMP_TWEAK)` (OsRng,
+   0..172_800 s in the past), mine PoW at `opts.pow`, sign with the
+   ephemeral key.
+
+### `unwrap_message`
+
+```rust
+pub async fn unwrap_message(
+    event: &Event,
+    trade_keys: &Keys,
+) -> Result<Option<UnwrappedMessage>, MostroError>
+```
+
+Contract:
+
+- `Ok(Some(_))` on successful unwrap **and** (when `signed`)
+  successful signature verification.
+- `Ok(None)` **only** when the outer NIP-44 layer cannot be decrypted
+  with `trade_keys`. This is the canonical "not addressed to me"
+  signal — callers can iterate across multiple candidate trade keys
+  and treat `None` as "try the next one".
+- `Err(MostroInternalErr(_))` for every other failure: wrong event
+  kind, corrupted seal JSON, invalid seal signature, NIP-59
+  `SenderMismatch`, malformed inner tuple JSON, malformed signature
+  hex, signature that does not verify against `sender`.
+
+The `Signer` / non-`Signer` split on `nip59::Error` is used to
+implement this contract (see "Error routing" below).
+
+### `validate_response`
+
+```rust
+pub fn validate_response(
+    message: &Message,
+    expected_request_id: Option<u64>,
+) -> Result<(), MostroError>
+```
+
+Post-unwrap validator for responses from a Mostro node.
+
+- Returns `Err(MostroCantDo(reason))` when the payload is `CantDo`
+  (defaults to `CantDoReason::InvalidAction` when the reason is
+  absent).
+- When `expected_request_id` is provided, enforces that the inner
+  message's `request_id` matches, unless the action is on the
+  unsolicited-push allow-list (`BuyerTookOrder`,
+  `HoldInvoicePayment*`, `WaitingSellerToPay`, `WaitingBuyerInvoice`,
+  `BuyerInvoiceAccepted`, `PurchaseCompleted`, `Released`,
+  `FiatSentOk`, `Canceled`, `CooperativeCancel*`,
+  `DisputeInitiatedByPeer`, `Admin*`, `PaymentFailed`,
+  `InvoiceUpdated`, `Rate`, `RateReceived`, `SendDm`), in which case a
+  missing `request_id` is accepted.
+
+Mismatched or unexpectedly-missing request ids surface as
+`ServiceError::UnexpectedError`.
+
+## Error routing
+
+`nip59::extract_rumor` (from `nostr-sdk`) returns four error variants.
+`unwrap_message` routes them as follows:
+
+| Upstream variant          | Cause                                   | Result               |
+|---------------------------|-----------------------------------------|----------------------|
+| `Signer(_)`               | outer NIP-44 decrypt failed             | `Ok(None)`           |
+| `Event(_)`                | bad seal JSON / signature / rumor JSON  | `Err(NostrError)`    |
+| `SenderMismatch`          | rumor author ≠ seal author              | `Err(NostrError)`    |
+| `NotGiftWrap`             | wrong kind (pre-checked, defensive)     | `Err(NostrError)`    |
+
+The `p` tag is **not** used as an addressing filter. NIP-44 decrypt
+success is a cryptographic proof of addressing; a `p` tag is a
+relay-routing hint that can be absent, spoofed, or mismatched without
+affecting decrypt-ability.
+
+## Security properties
+
+### Trade-identity binding
+
+When `signed = true`, the inner tuple carries a Schnorr signature
+over the exact JSON bytes of `message`, produced with `trade_keys`.
+`unwrap_message` parses the signature strictly and verifies it
+against `unwrapped.sender` (the trade pubkey that signed the seal).
+
+The verification is redundant with the seal signature in the
+honest-client case — `nostr-sdk` already rejects seals whose author
+does not match the rumor — but it defends against any future drift
+where the two layers diverge, and it gives callers a single
+`UnwrappedMessage.signature` they can re-verify or forward on its
+own. Malformed signatures and non-verifying signatures both surface
+as errors: "the sender did not sign" and "the sender claims a
+signature we cannot trust" must never look the same to the caller.
+
+### Timestamp blur
+
+Per NIP-59, GiftWrap `created_at` should be randomized to obscure the
+real send time. The module calls
+`Timestamp::tweaked(nip59::RANGE_RANDOM_TIMESTAMP_TWEAK)`, which draws
+a uniformly random `u64` in `0..172_800` (two days) from `OsRng` and
+subtracts it from the current Unix second. The `Timestamp::tweaked`
+helper is also what `nostr-sdk`'s own `make_seal` uses, so wrap and
+seal metadata share the same distribution.
+
+### PoW scope
+
+`WrapOptions.pow` applies only to the outer GiftWrap event. The
+rumor is encrypted inside the seal and never published on its own,
+so mining its event id is pure CPU waste. The seal itself is not
+mined; `nostr-sdk` does not expose a PoW hook on `EventBuilder::seal`
+and the seal's id is not observable on relays in any meaningful way.
+
+### Ephemeral outer signer
+
+Every call to `wrap_message` generates a fresh
+`Keys::generate()` for the GiftWrap signer. There is no reuse
+across wraps, no persistence, and no correlation between trade
+identity and the key visible on the wire.
+
+## Usage
+
+### Sending a request to a Mostro node
+
+```rust
+use mostro_core::prelude::*;
+
+let wrapped = wrap_message(
+    &message,                // Message with an explicit request_id
+    &trade_keys,             // per-trade keys
+    mostro_pubkey,           // PublicKey of the Mostro node
+    WrapOptions::default(),  // signed = true, pow = 0, no expiration
+)
+.await?;
+
+// Caller publishes `wrapped` to its relay pool.
+```
+
+### Handling incoming events across multiple candidate trade keys
+
+```rust
+async fn try_unwrap(event: &Event, candidates: &[Keys]) -> Option<UnwrappedMessage> {
+    for keys in candidates {
+        match unwrap_message(event, keys).await {
+            Ok(Some(msg)) => return Some(msg),   // addressed to this trade key
+            Ok(None) => continue,                // not this key, try the next
+            Err(_e) => {
+                // genuine protocol error — log, drop, or escalate
+                return None;
+            }
+        }
+    }
+    None
+}
+```
+
+`Ok(None)` is cheap to iterate on; `Err(_)` is rare and worth
+surfacing in logs or metrics.
+
+### Validating a response
+
+```rust
+let unwrapped = unwrap_message(&event, &trade_keys).await?
+    .ok_or_else(/* not addressed to us */)?;
+
+validate_response(&unwrapped.message, Some(request_id))?;
+
+// Re-verify the signature if the caller wants to forward it:
+if let Some(sig) = unwrapped.signature {
+    let json = unwrapped.message.as_json()?;
+    assert!(Message::verify_signature(json, unwrapped.sender, sig));
+}
+```
+
+## Dependency surface
+
+- `nostr-sdk = "0.44.1"` with features `nip44`, `nip59`.
+- `serde_json` for the inner tuple.
+- No new direct RNG dependency; randomness flows through
+  `nostr-sdk`'s `Timestamp::tweaked` (OsRng).
+
+## Testing
+
+`src/nip59.rs` carries the behavioral tests that lock in the
+contract:
+
+- `wrap_then_unwrap_roundtrip`
+- `signature_is_verifiable_with_trade_pubkey`
+- `unsigned_wrap_has_no_signature`
+- `expiration_tag_is_set_when_provided`
+- `unwrap_with_wrong_trade_keys_returns_none` — outer decrypt failure
+  path.
+- `unwrap_with_corrupted_seal_returns_err` — decryptable but
+  semantically invalid seal payload.
+- `unwrap_with_malformed_signature_errors` — `Some("not-a-hex-sig")`
+  in the tuple must not silently become `None`.
+- `unwrap_with_signature_for_other_content_errors` — well-formed sig
+  that does not verify against the declared sender must error.
+- `validate_response_*` suite covering `CantDo`, request-id match /
+  mismatch, and the unsolicited-action allow-list.

--- a/src/dispute.rs
+++ b/src/dispute.rs
@@ -117,7 +117,7 @@ impl SolverDisputeInfo {
 
         if let Some(initiator) = initiator {
             let now = Timestamp::now();
-            let initiator_operating_days = (now.as_u64() - initiator.created_at as u64) / 86400;
+            let initiator_operating_days = (now.as_secs() - initiator.created_at as u64) / 86400;
             initiator_info = Some(UserInfo {
                 rating: initiator.total_rating,
                 reviews: initiator.total_reviews,
@@ -127,7 +127,7 @@ impl SolverDisputeInfo {
         }
         if let Some(counterpart) = counterpart {
             let now = Timestamp::now();
-            let couterpart_operating_days = (now.as_u64() - counterpart.created_at as u64) / 86400;
+            let couterpart_operating_days = (now.as_secs() - counterpart.created_at as u64) / 86400;
             counterpart_info = Some(UserInfo {
                 rating: counterpart.total_rating,
                 reviews: counterpart.total_reviews,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod dispute;
 pub mod error;
 pub mod message;
+pub mod nip59;
 pub mod order;
 pub mod prelude;
 pub mod rating;

--- a/src/nip59.rs
+++ b/src/nip59.rs
@@ -1,0 +1,466 @@
+//! NIP-59 GiftWrap transport for Mostro messages.
+//!
+//! Every message exchanged with a Mostro node travels through the same
+//! pipeline:
+//!
+//! ```text
+//! Message -> JSON((Message, Option<Signature>)) -> Rumor -> Seal -> GiftWrap
+//! ```
+//!
+//! This module centralizes wrap/unwrap so clients do not need to reimplement
+//! NIP-59 glue themselves. It does not manage relays, subscriptions, waiters
+//! or persistence — the returned `Event` is ready to publish, and the caller
+//! decides how to do so.
+
+use std::str::FromStr;
+
+use crate::message::{Action, Message, Payload};
+use crate::prelude::{CantDoReason, MostroError, ServiceError};
+use nostr_sdk::nips::{nip44, nip59};
+use nostr_sdk::prelude::*;
+
+/// Options controlling how a Mostro message is wrapped.
+#[derive(Debug, Clone)]
+pub struct WrapOptions {
+    /// NIP-13 proof-of-work difficulty applied to the outer GiftWrap event.
+    pub pow: u8,
+    /// Optional expiration tag for the outer GiftWrap event.
+    pub expiration: Option<Timestamp>,
+    /// When true the inner rumor content is `(Message, Some(Signature))`,
+    /// with the signature produced from the JSON of `Message` using
+    /// `trade_keys`. When false the content is `(Message, None)`. Traffic
+    /// to a Mostro node always uses `true`.
+    pub signed: bool,
+}
+
+impl Default for WrapOptions {
+    fn default() -> Self {
+        Self {
+            pow: 0,
+            expiration: None,
+            signed: true,
+        }
+    }
+}
+
+/// A Mostro message recovered from an incoming GiftWrap, plus metadata from
+/// the outer envelopes.
+#[derive(Debug, Clone)]
+pub struct UnwrappedMessage {
+    /// The logical Mostro message carried inside the rumor.
+    pub message: Message,
+    /// Signature of the JSON-serialized `Message`, produced with the sender's
+    /// trade keys. Present only when the sender set `signed = true`.
+    pub signature: Option<Signature>,
+    /// Rumor author (the sender's trade public key).
+    pub sender: PublicKey,
+    /// Rumor `created_at` timestamp.
+    pub created_at: Timestamp,
+}
+
+/// Build a GiftWrap event (`kind: 1059`) ready to be published to a relay.
+///
+/// * `message` — the Mostro message to send.
+/// * `trade_keys` — per-trade keys. Author of the rumor, signer of the Seal,
+///   and signer of the inner tuple signature when `opts.signed == true`.
+/// * `receiver` — the Mostro node public key.
+/// * `opts` — wrap options (PoW, expiration, signed).
+///
+/// `nostr-sdk` 0.44 enforces that the rumor author equals the seal signer
+/// (NIP-59 `SenderMismatch`), so both layers are signed with `trade_keys`.
+/// The inner tuple signature (produced with `trade_keys`) is what allows
+/// Mostro to cryptographically bind the message to the trade identity.
+pub async fn wrap_message(
+    message: &Message,
+    trade_keys: &Keys,
+    receiver: PublicKey,
+    opts: WrapOptions,
+) -> Result<Event, MostroError> {
+    let message_json = message.as_json().map_err(MostroError::MostroInternalErr)?;
+
+    let content = if opts.signed {
+        let sig = Message::sign(message_json, trade_keys);
+        serde_json::to_string(&(message, Some(sig.to_string())))
+            .map_err(|_| MostroError::MostroInternalErr(ServiceError::MessageSerializationError))?
+    } else {
+        serde_json::to_string(&(message, Option::<String>::None))
+            .map_err(|_| MostroError::MostroInternalErr(ServiceError::MessageSerializationError))?
+    };
+
+    let rumor = EventBuilder::text_note(content)
+        .pow(opts.pow)
+        .build(trade_keys.public_key());
+
+    let seal: Event = EventBuilder::seal(trade_keys, &receiver, rumor)
+        .await
+        .map_err(|e| MostroError::MostroInternalErr(ServiceError::NostrError(e.to_string())))?
+        .sign(trade_keys)
+        .await
+        .map_err(|e| MostroError::MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
+
+    gift_wrap_from_seal_with_pow(&seal, receiver, opts.pow, opts.expiration)
+}
+
+/// Wrap an already built Seal into a NIP-59 GiftWrap with optional PoW and
+/// expiration. The outer event is signed with a freshly generated ephemeral
+/// key and carries a mandatory `p` tag pointing at `receiver`.
+fn gift_wrap_from_seal_with_pow(
+    seal: &Event,
+    receiver: PublicKey,
+    pow: u8,
+    expiration: Option<Timestamp>,
+) -> Result<Event, MostroError> {
+    if seal.kind != Kind::Seal {
+        return Err(MostroError::MostroInternalErr(
+            ServiceError::UnexpectedError("expected Seal kind".to_string()),
+        ));
+    }
+
+    let ephemeral = Keys::generate();
+    let encrypted = nip44::encrypt(
+        ephemeral.secret_key(),
+        &receiver,
+        seal.as_json(),
+        nip44::Version::default(),
+    )
+    .map_err(|e| MostroError::MostroInternalErr(ServiceError::EncryptionError(e.to_string())))?;
+
+    let mut tags: Vec<Tag> = Vec::new();
+    if let Some(exp) = expiration {
+        tags.push(Tag::expiration(exp));
+    }
+    tags.push(Tag::public_key(receiver));
+
+    EventBuilder::new(Kind::GiftWrap, encrypted)
+        .tags(tags)
+        .custom_created_at(random_past_timestamp())
+        .pow(pow)
+        .sign_with_keys(&ephemeral)
+        .map_err(|e| MostroError::MostroInternalErr(ServiceError::NostrError(e.to_string())))
+}
+
+/// Random timestamp in the recent past, per NIP-59 recommendation to blur
+/// real send time. Range: up to two days in the past.
+fn random_past_timestamp() -> Timestamp {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or_default();
+    // Deterministic-enough jitter sourced from the ephemeral key generation
+    // is not available here; use a pseudo-random seconds offset in [0, 172800).
+    let jitter = (Timestamp::now().as_secs() ^ now).rem_euclid(172_800);
+    Timestamp::from_secs(now.saturating_sub(jitter))
+}
+
+/// Try to open an incoming GiftWrap with the given `trade_keys`.
+///
+/// Returns `Ok(None)` when the wrap was not addressed to these keys (the
+/// underlying `nip59::extract_rumor` call fails), so the caller can try
+/// multiple trade keys without treating each miss as a fatal error. Any
+/// other failure (JSON malformed, unexpected layer) yields `Err`.
+pub async fn unwrap_message(
+    event: &Event,
+    trade_keys: &Keys,
+) -> Result<Option<UnwrappedMessage>, MostroError> {
+    if event.kind != Kind::GiftWrap {
+        return Err(MostroError::MostroInternalErr(
+            ServiceError::UnexpectedError("event is not a GiftWrap".to_string()),
+        ));
+    }
+
+    let unwrapped = match nip59::extract_rumor(trade_keys, event).await {
+        Ok(u) => u,
+        Err(_) => return Ok(None),
+    };
+
+    let (message, sig_str): (Message, Option<String>) =
+        serde_json::from_str(&unwrapped.rumor.content)
+            .map_err(|_| MostroError::MostroInternalErr(ServiceError::MessageSerializationError))?;
+
+    let signature = sig_str.as_deref().and_then(|s| Signature::from_str(s).ok());
+
+    Ok(Some(UnwrappedMessage {
+        message,
+        signature,
+        sender: unwrapped.sender,
+        created_at: unwrapped.rumor.created_at,
+    }))
+}
+
+/// Validate a response received from a Mostro node.
+///
+/// * Returns `Err(MostroCantDo(reason))` when the payload is `CantDo`.
+/// * Returns `Err(MostroInternalErr(...))` when `expected_request_id` is
+///   provided and the inner message carries a different id, or no id at all
+///   on an action that requires one.
+/// * Otherwise returns `Ok(())`.
+///
+/// The allow-list of actions that may arrive without a `request_id` (server
+/// push messages such as state transitions, DMs, payment failures, etc.) is
+/// intentionally kept on the caller side, because the exact set depends on
+/// the client flow; this function only enforces the universal rules.
+pub fn validate_response(
+    message: &Message,
+    expected_request_id: Option<u64>,
+) -> Result<(), MostroError> {
+    let inner = message.get_inner_message_kind();
+
+    if let Some(Payload::CantDo(reason)) = &inner.payload {
+        return Err(MostroError::MostroCantDo(
+            reason.clone().unwrap_or(CantDoReason::InvalidAction),
+        ));
+    }
+
+    if let Some(expected) = expected_request_id {
+        match inner.request_id {
+            Some(got) if got == expected => {}
+            Some(_) => {
+                return Err(MostroError::MostroInternalErr(
+                    ServiceError::UnexpectedError("mismatched request_id".to_string()),
+                ));
+            }
+            None => {
+                if !action_accepts_missing_request_id(&inner.action) {
+                    return Err(MostroError::MostroInternalErr(
+                        ServiceError::UnexpectedError(
+                            "missing request_id on a response that requires one".to_string(),
+                        ),
+                    ));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Actions that may legitimately arrive without a `request_id` even when the
+/// caller was waiting on one (unsolicited server-initiated events).
+fn action_accepts_missing_request_id(action: &Action) -> bool {
+    matches!(
+        action,
+        Action::BuyerTookOrder
+            | Action::HoldInvoicePaymentAccepted
+            | Action::HoldInvoicePaymentSettled
+            | Action::HoldInvoicePaymentCanceled
+            | Action::WaitingSellerToPay
+            | Action::WaitingBuyerInvoice
+            | Action::BuyerInvoiceAccepted
+            | Action::PurchaseCompleted
+            | Action::Released
+            | Action::FiatSentOk
+            | Action::Canceled
+            | Action::CooperativeCancelInitiatedByPeer
+            | Action::CooperativeCancelAccepted
+            | Action::DisputeInitiatedByPeer
+            | Action::AdminSettled
+            | Action::AdminCanceled
+            | Action::AdminTookDispute
+            | Action::PaymentFailed
+            | Action::InvoiceUpdated
+            | Action::Rate
+            | Action::RateReceived
+            | Action::SendDm
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::{Action, MessageKind, Payload};
+    use uuid::uuid;
+
+    fn sample_order_message(request_id: Option<u64>) -> Message {
+        let peer = crate::message::Peer::new(
+            "npub1testjsf0runcqdht5apkfcalajxkf8txdxqqk5kgm0agc38ke4vsfsgzf8".to_string(),
+            None,
+        );
+        Message::Order(MessageKind::new(
+            Some(uuid!("308e1272-d5f4-47e6-bd97-3504baea9c23")),
+            request_id,
+            Some(1),
+            Action::FiatSentOk,
+            Some(Payload::Peer(peer)),
+        ))
+    }
+
+    #[tokio::test]
+    async fn wrap_then_unwrap_roundtrip() {
+        let trade_keys = Keys::generate();
+        let receiver_keys = Keys::generate();
+
+        let message = sample_order_message(Some(42));
+
+        let wrapped = wrap_message(
+            &message,
+            &trade_keys,
+            receiver_keys.public_key(),
+            WrapOptions::default(),
+        )
+        .await
+        .expect("wrap");
+
+        assert_eq!(wrapped.kind, Kind::GiftWrap);
+        assert!(wrapped
+            .tags
+            .iter()
+            .any(|t| t.as_slice().first().map(|s| s.as_str()) == Some("p")));
+
+        let unwrapped = unwrap_message(&wrapped, &receiver_keys)
+            .await
+            .expect("unwrap result")
+            .expect("unwrap some");
+
+        assert_eq!(unwrapped.sender, trade_keys.public_key());
+        assert_eq!(
+            unwrapped.message.as_json().unwrap(),
+            message.as_json().unwrap()
+        );
+        assert!(unwrapped.signature.is_some());
+    }
+
+    #[tokio::test]
+    async fn unwrap_with_wrong_trade_keys_returns_none() {
+        let trade_keys = Keys::generate();
+        let receiver_keys = Keys::generate();
+        let stranger_keys = Keys::generate();
+
+        let wrapped = wrap_message(
+            &sample_order_message(Some(1)),
+            &trade_keys,
+            receiver_keys.public_key(),
+            WrapOptions::default(),
+        )
+        .await
+        .expect("wrap");
+
+        let result = unwrap_message(&wrapped, &stranger_keys)
+            .await
+            .expect("call should not error");
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn signature_is_verifiable_with_trade_pubkey() {
+        let trade_keys = Keys::generate();
+        let receiver_keys = Keys::generate();
+        let message = sample_order_message(Some(7));
+
+        let wrapped = wrap_message(
+            &message,
+            &trade_keys,
+            receiver_keys.public_key(),
+            WrapOptions::default(),
+        )
+        .await
+        .unwrap();
+
+        let unwrapped = unwrap_message(&wrapped, &receiver_keys)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let sig = unwrapped.signature.expect("signed");
+        let json = unwrapped.message.as_json().unwrap();
+        assert!(Message::verify_signature(
+            json,
+            trade_keys.public_key(),
+            sig
+        ));
+    }
+
+    #[tokio::test]
+    async fn unsigned_wrap_has_no_signature() {
+        let trade_keys = Keys::generate();
+        let receiver_keys = Keys::generate();
+
+        let wrapped = wrap_message(
+            &sample_order_message(Some(3)),
+            &trade_keys,
+            receiver_keys.public_key(),
+            WrapOptions {
+                signed: false,
+                ..WrapOptions::default()
+            },
+        )
+        .await
+        .expect("wrap");
+
+        let unwrapped = unwrap_message(&wrapped, &receiver_keys)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(unwrapped.signature.is_none());
+    }
+
+    #[tokio::test]
+    async fn expiration_tag_is_set_when_provided() {
+        let trade_keys = Keys::generate();
+        let receiver_keys = Keys::generate();
+        let exp = Timestamp::from_secs(Timestamp::now().as_secs() + 3600);
+
+        let wrapped = wrap_message(
+            &sample_order_message(Some(1)),
+            &trade_keys,
+            receiver_keys.public_key(),
+            WrapOptions {
+                expiration: Some(exp),
+                ..WrapOptions::default()
+            },
+        )
+        .await
+        .expect("wrap");
+
+        let has_expiration = wrapped
+            .tags
+            .iter()
+            .any(|t| t.as_slice().first().map(|s| s.as_str()) == Some("expiration"));
+        assert!(has_expiration);
+    }
+
+    #[test]
+    fn validate_response_cant_do_short_circuits() {
+        let msg = Message::cant_do(
+            Some(uuid!("308e1272-d5f4-47e6-bd97-3504baea9c23")),
+            Some(5),
+            Some(Payload::CantDo(Some(CantDoReason::NotAuthorized))),
+        );
+        let err = validate_response(&msg, Some(5)).unwrap_err();
+        match err {
+            MostroError::MostroCantDo(CantDoReason::NotAuthorized) => {}
+            _ => panic!("expected CantDo(NotAuthorized)"),
+        }
+    }
+
+    #[test]
+    fn validate_response_request_id_match() {
+        let msg = sample_order_message(Some(9));
+        validate_response(&msg, Some(9)).unwrap();
+    }
+
+    #[test]
+    fn validate_response_request_id_mismatch_errors() {
+        let msg = sample_order_message(Some(9));
+        let err = validate_response(&msg, Some(10)).unwrap_err();
+        assert!(matches!(err, MostroError::MostroInternalErr(_)));
+    }
+
+    #[test]
+    fn validate_response_allows_unsolicited_actions_without_request_id() {
+        let msg = Message::Order(MessageKind::new(
+            Some(uuid!("308e1272-d5f4-47e6-bd97-3504baea9c23")),
+            None,
+            None,
+            Action::BuyerTookOrder,
+            None,
+        ));
+        validate_response(&msg, Some(1)).unwrap();
+    }
+
+    #[test]
+    fn validate_response_with_no_expected_id_is_ok() {
+        let msg = sample_order_message(None);
+        validate_response(&msg, None).unwrap();
+    }
+}

--- a/src/nip59.rs
+++ b/src/nip59.rs
@@ -133,32 +133,20 @@ fn gift_wrap_from_seal_with_pow(
 
     EventBuilder::new(Kind::GiftWrap, encrypted)
         .tags(tags)
-        .custom_created_at(random_past_timestamp())
+        .custom_created_at(Timestamp::tweaked(nip59::RANGE_RANDOM_TIMESTAMP_TWEAK))
         .pow(pow)
         .sign_with_keys(&ephemeral)
         .map_err(|e| MostroError::MostroInternalErr(ServiceError::NostrError(e.to_string())))
 }
 
-/// Random timestamp in the recent past, per NIP-59 recommendation to blur
-/// real send time. Range: up to two days in the past.
-fn random_past_timestamp() -> Timestamp {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or_default();
-    // Deterministic-enough jitter sourced from the ephemeral key generation
-    // is not available here; use a pseudo-random seconds offset in [0, 172800).
-    let jitter = (Timestamp::now().as_secs() ^ now).rem_euclid(172_800);
-    Timestamp::from_secs(now.saturating_sub(jitter))
-}
-
 /// Try to open an incoming GiftWrap with the given `trade_keys`.
 ///
-/// Returns `Ok(None)` when the wrap was not addressed to these keys (the
-/// underlying `nip59::extract_rumor` call fails), so the caller can try
-/// multiple trade keys without treating each miss as a fatal error. Any
-/// other failure (JSON malformed, unexpected layer) yields `Err`.
+/// Returns `Ok(None)` only when the outer NIP-44 layer could not be
+/// decrypted with `trade_keys` — the canonical "not addressed to me"
+/// signal, so callers can try multiple trade keys without treating each
+/// miss as fatal. Every other failure (corrupted seal, malformed rumor
+/// JSON, seal/rumor pubkey mismatch, invalid signatures, etc.) yields
+/// `Err` so callers can tell "not mine" apart from "broken".
 pub async fn unwrap_message(
     event: &Event,
     trade_keys: &Keys,
@@ -171,7 +159,13 @@ pub async fn unwrap_message(
 
     let unwrapped = match nip59::extract_rumor(trade_keys, event).await {
         Ok(u) => u,
-        Err(_) => return Ok(None),
+        // Outer NIP-44 decrypt failed — wrap was not for us.
+        Err(nip59::Error::Signer(_)) => return Ok(None),
+        Err(e) => {
+            return Err(MostroError::MostroInternalErr(ServiceError::NostrError(
+                e.to_string(),
+            )));
+        }
     };
 
     let (message, sig_str): (Message, Option<String>) =
@@ -318,6 +312,35 @@ mod tests {
             message.as_json().unwrap()
         );
         assert!(unwrapped.signature.is_some());
+    }
+
+    #[tokio::test]
+    async fn unwrap_with_corrupted_seal_returns_err() {
+        let receiver_keys = Keys::generate();
+        let ephemeral = Keys::generate();
+
+        // GiftWrap addressed to `receiver_keys` whose outer ciphertext
+        // decrypts successfully but yields a string that is not a valid
+        // seal Event JSON. `extract_rumor` must surface this as an error,
+        // not be silently absorbed as `Ok(None)`.
+        let encrypted = nip44::encrypt(
+            ephemeral.secret_key(),
+            &receiver_keys.public_key(),
+            "not a seal",
+            nip44::Version::default(),
+        )
+        .expect("encrypt");
+
+        let corrupted = EventBuilder::new(Kind::GiftWrap, encrypted)
+            .tags([Tag::public_key(receiver_keys.public_key())])
+            .sign_with_keys(&ephemeral)
+            .expect("sign");
+
+        let result = unwrap_message(&corrupted, &receiver_keys).await;
+        assert!(
+            matches!(result, Err(MostroError::MostroInternalErr(_))),
+            "expected Err for corrupted gift wrap, got {result:?}",
+        );
     }
 
     #[tokio::test]

--- a/src/nip59.rs
+++ b/src/nip59.rs
@@ -87,9 +87,10 @@ pub async fn wrap_message(
             .map_err(|_| MostroError::MostroInternalErr(ServiceError::MessageSerializationError))?
     };
 
-    let rumor = EventBuilder::text_note(content)
-        .pow(opts.pow)
-        .build(trade_keys.public_key());
+    // PoW only applies to the outer GiftWrap (per WrapOptions docs); the
+    // rumor is encrypted inside the seal and never published on its own,
+    // so mining its event id would burn CPU for nothing.
+    let rumor = EventBuilder::text_note(content).build(trade_keys.public_key());
 
     let seal: Event = EventBuilder::seal(trade_keys, &receiver, rumor)
         .await
@@ -172,7 +173,25 @@ pub async fn unwrap_message(
         serde_json::from_str(&unwrapped.rumor.content)
             .map_err(|_| MostroError::MostroInternalErr(ServiceError::MessageSerializationError))?;
 
-    let signature = sig_str.as_deref().and_then(|s| Signature::from_str(s).ok());
+    let signature = match sig_str {
+        Some(s) => {
+            let sig = Signature::from_str(&s).map_err(|e| {
+                MostroError::MostroInternalErr(ServiceError::UnexpectedError(format!(
+                    "malformed rumor signature: {e}"
+                )))
+            })?;
+            let message_json = message.as_json().map_err(MostroError::MostroInternalErr)?;
+            if !Message::verify_signature(message_json, unwrapped.sender, sig) {
+                return Err(MostroError::MostroInternalErr(
+                    ServiceError::UnexpectedError(
+                        "rumor signature does not verify against sender".to_string(),
+                    ),
+                ));
+            }
+            Some(sig)
+        }
+        None => None,
+    };
 
     Ok(Some(UnwrappedMessage {
         message,
@@ -340,6 +359,67 @@ mod tests {
         assert!(
             matches!(result, Err(MostroError::MostroInternalErr(_))),
             "expected Err for corrupted gift wrap, got {result:?}",
+        );
+    }
+
+    // Build a GiftWrap by hand with a custom inner rumor tuple so tests
+    // can inject a malformed or wrong-signature payload that `wrap_message`
+    // would never emit.
+    async fn wrap_with_raw_inner(
+        trade_keys: &Keys,
+        receiver: PublicKey,
+        inner: (&Message, Option<String>),
+    ) -> Event {
+        let content = serde_json::to_string(&inner).unwrap();
+        let rumor = EventBuilder::text_note(content).build(trade_keys.public_key());
+        let seal = EventBuilder::seal(trade_keys, &receiver, rumor)
+            .await
+            .unwrap()
+            .sign(trade_keys)
+            .await
+            .unwrap();
+        gift_wrap_from_seal_with_pow(&seal, receiver, 0, None).unwrap()
+    }
+
+    #[tokio::test]
+    async fn unwrap_with_malformed_signature_errors() {
+        let trade_keys = Keys::generate();
+        let receiver_keys = Keys::generate();
+        let msg = sample_order_message(Some(1));
+
+        let wrapped = wrap_with_raw_inner(
+            &trade_keys,
+            receiver_keys.public_key(),
+            (&msg, Some("not-a-hex-signature".to_string())),
+        )
+        .await;
+
+        let result = unwrap_message(&wrapped, &receiver_keys).await;
+        assert!(
+            matches!(result, Err(MostroError::MostroInternalErr(_))),
+            "malformed signature must surface as Err, got {result:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn unwrap_with_signature_for_other_content_errors() {
+        let trade_keys = Keys::generate();
+        let receiver_keys = Keys::generate();
+        let msg = sample_order_message(Some(1));
+        // Well-formed signature, but over a completely different payload.
+        let bogus = Message::sign("not the real message".to_string(), &trade_keys);
+
+        let wrapped = wrap_with_raw_inner(
+            &trade_keys,
+            receiver_keys.public_key(),
+            (&msg, Some(bogus.to_string())),
+        )
+        .await;
+
+        let result = unwrap_message(&wrapped, &receiver_keys).await;
+        assert!(
+            matches!(result, Err(MostroError::MostroInternalErr(_))),
+            "non-verifying signature must surface as Err, got {result:?}",
         );
     }
 

--- a/src/order.rs
+++ b/src/order.rs
@@ -337,7 +337,7 @@ impl Order {
 
     /// Set the timestamp to now
     pub fn set_timestamp_now(&mut self) {
-        self.taken_at = Timestamp::now().as_u64() as i64
+        self.taken_at = Timestamp::now().as_secs() as i64
     }
 
     /// Check if a user is creating a full privacy order so he doesn't to have reputation

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,6 +9,9 @@ pub use crate::message::{
     Action, Message, MessageKind, Payload, PaymentFailedInfo, Peer, RestoreSessionInfo,
     RestoredDisputeHelper, RestoredDisputesInfo, RestoredOrderHelper, RestoredOrdersInfo,
 };
+pub use crate::nip59::{
+    unwrap_message, validate_response, wrap_message, UnwrappedMessage, WrapOptions,
+};
 pub use crate::order::{Kind, Order, SmallOrder, Status};
 pub use crate::rating::Rating;
 pub use crate::user::{User, UserInfo};


### PR DESCRIPTION
Introduce a new `nip59` module that centralizes the send/receive pipeline every Mostro client needs to talk to the node, so `mostrix`, `mostro-cli`, `mostro` node and `mostro-app-v2` no longer reimplement the same NIP-59 glue.

- `wrap_message(message, trade_keys, receiver, opts)` builds a GiftWrap event (`kind: 1059`) from a `Message`, with optional PoW and expiration. The inner rumor carries the `(Message, Option<Signature>)` tuple that Mostro expects on the wire, signed with the trade keys when `opts.signed` is true.
- `unwrap_message(event, trade_keys)` opens an incoming GiftWrap, returns the `Message` plus sender and timestamp metadata, and reports "not for me" as `Ok(None)` so a caller can probe multiple trade keys without treating each miss as a fatal error.
- `validate_response(message, expected_request_id)` short-circuits on `CantDo` payloads and enforces request/response `request_id` correlation, with an allow-list of unsolicited actions that are legitimately id-less.

Also:

- Bump `nostr-sdk` from 0.43.0 to 0.44.1 and enable the `nip44`/`nip59` features required by the new module.
- Replace deprecated `Timestamp::as_u64` calls with `as_secs` in `dispute.rs` and `order.rs`.
- Add `tokio` as a dev-dependency to drive the async test cases.
- Re-export the new API from `prelude`.

Implementation note: nostr-sdk 0.44 enforces that the rumor author equals the seal signer (`SenderMismatch`). Both layers are therefore signed with the trade keys. The inner tuple signature, still produced with the trade keys, continues to bind each message to the trade identity.

Refs #138

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GiftWrap message wrapping and unwrapping functionality
  * Added message response validation with signature verification
  * Added expiration and proof-of-work configuration options for messages

* **Chores**
  * Updated nostr-sdk dependency to 0.44.1 with NIP-44 and NIP-59 protocol support
  * Added testing framework dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->