### PR TITLE
docs: document all public items across the crate

### DIFF
--- a/src/dispute.rs
+++ b/src/dispute.rs
@@ -1,3 +1,14 @@
+//! Dispute representation and lifecycle states.
+//!
+//! A [`Dispute`] is opened when one of the counterparts of a trade asks
+//! Mostro to involve a solver. The dispute moves through a small state
+//! machine described by [`Status`] until it is either settled, refunded or
+//! released.
+//!
+//! [`SolverDisputeInfo`] is the payload surfaced to solvers with all the
+//! trade details they need to render the dispute in their UI without
+//! loading additional data.
+
 use crate::{order::Order, user::User, user::UserInfo};
 use chrono::Utc;
 use nostr_sdk::Timestamp;
@@ -9,21 +20,22 @@ use sqlx_crud::SqlxCrud;
 use std::{fmt::Display, str::FromStr};
 use uuid::Uuid;
 
-/// Each status that a dispute can have
+/// Lifecycle status of a [`Dispute`].
 #[cfg_attr(feature = "sqlx", derive(Type))]
 #[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum Status {
-    /// Dispute initiated and waiting to be taken by a solver
+    /// Dispute has been initiated and is waiting to be taken by a solver.
     #[default]
     Initiated,
-    /// Taken by a solver
+    /// A solver has taken the dispute and is working on it.
     InProgress,
-    /// Canceled by admin/solver and refunded to seller
+    /// Admin/solver canceled the trade and refunded the seller.
     SellerRefunded,
-    /// Settled seller's invoice by admin/solver and started to pay sats to buyer
+    /// Admin/solver settled the seller's hold invoice and initiated payment
+    /// to the buyer.
     Settled,
-    /// Released by the seller
+    /// The seller released the funds before the dispute was resolved.
     Released,
 }
 
@@ -42,6 +54,9 @@ impl Display for Status {
 impl FromStr for Status {
     type Err = ();
 
+    /// Parse a [`Status`] from its kebab-case string representation.
+    ///
+    /// Returns `Err(())` if `s` does not match a known variant.
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s {
             "initiated" => std::result::Result::Ok(Self::Initiated),
@@ -54,54 +69,96 @@ impl FromStr for Status {
     }
 }
 
-/// Database representation of a dispute
+/// Database representation of a dispute.
+///
+/// Disputes are always bound to a parent [`Order`]; `order_previous_status`
+/// preserves the status the order had before the dispute was filed so that
+/// it can be restored if the dispute is dismissed.
 #[cfg_attr(feature = "sqlx", derive(FromRow, SqlxCrud), external_id)]
 #[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct Dispute {
-    /// Unique identifier for the dispute
+    /// Unique identifier for the dispute.
     pub id: Uuid,
-    /// Order ID that the dispute is related to
+    /// Id of the order the dispute is attached to.
     pub order_id: Uuid,
-    /// Status of the dispute
+    /// Current [`Status`] of the dispute, serialized as kebab-case.
     pub status: String,
-    /// Previous status of the order before the dispute was created
+    /// The status the underlying order had before the dispute was opened.
     pub order_previous_status: String,
-    /// Public key of the solver
+    /// Public key of the solver that has taken the dispute, if any.
     pub solver_pubkey: Option<String>,
-    /// Timestamp when the dispute was created
+    /// Unix timestamp (seconds) when the dispute was created.
     pub created_at: i64,
-    /// Timestamp when the dispute was taken by a solver
+    /// Unix timestamp (seconds) when the dispute was taken by a solver.
+    /// `0` when it has not been taken yet.
     pub taken_at: i64,
 }
 
+/// Extended dispute view for solvers.
+///
+/// Bundles the [`Dispute`] together with the key fields of its parent
+/// [`Order`] so a solver UI can render everything needed without additional
+/// database lookups, while still respecting the `full privacy` setting of
+/// each counterpart.
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 pub struct SolverDisputeInfo {
+    /// Order id the dispute is attached to.
     pub id: Uuid,
+    /// Order kind (`buy` or `sell`), serialized as kebab-case.
     pub kind: String,
+    /// Order status at the time the dispute view was built.
     pub status: String,
+    /// Payment hash of the hold invoice.
     pub hash: Option<String>,
+    /// Preimage revealed once the hold invoice is settled.
     pub preimage: Option<String>,
+    /// Status the order had immediately before the dispute was opened.
     pub order_previous_status: String,
+    /// Trade public key of the dispute initiator.
     pub initiator_pubkey: String,
+    /// Buyer's trade public key, if available.
     pub buyer_pubkey: Option<String>,
+    /// Seller's trade public key, if available.
     pub seller_pubkey: Option<String>,
+    /// `true` when the initiator is operating in full privacy mode, hiding
+    /// its reputation.
     pub initiator_full_privacy: bool,
+    /// `true` when the counterpart is operating in full privacy mode.
     pub counterpart_full_privacy: bool,
+    /// Reputation snapshot of the initiator, when privacy allows it.
     pub initiator_info: Option<UserInfo>,
+    /// Reputation snapshot of the counterpart, when privacy allows it.
     pub counterpart_info: Option<UserInfo>,
+    /// Premium percentage applied to the order price.
     pub premium: i64,
+    /// Payment method agreed upon for the fiat leg.
     pub payment_method: String,
+    /// Sats amount of the trade.
     pub amount: i64,
+    /// Fiat amount of the trade.
     pub fiat_amount: i64,
+    /// Mostro fee charged for the trade.
     pub fee: i64,
+    /// Lightning routing fee paid when settling the trade.
     pub routing_fee: i64,
+    /// Buyer's Lightning invoice, if already provided.
     pub buyer_invoice: Option<String>,
+    /// Unix timestamp (seconds) when the hold invoice was locked in.
     pub invoice_held_at: i64,
+    /// Unix timestamp (seconds) when the order was taken.
     pub taken_at: i64,
+    /// Unix timestamp (seconds) when the order was created.
     pub created_at: i64,
 }
 
 impl SolverDisputeInfo {
+    /// Build a [`SolverDisputeInfo`] from an order, its dispute and the
+    /// optional [`User`] records of both counterparts.
+    ///
+    /// When a [`User`] is provided, the corresponding privacy flag is set to
+    /// `false` and a [`UserInfo`] snapshot is included (rating, reviews,
+    /// operating days computed from `created_at`). When a [`User`] is `None`,
+    /// the party is considered to be operating in full privacy mode.
     pub fn new(
         order: &Order,
         dispute: &Dispute,
@@ -165,6 +222,13 @@ impl SolverDisputeInfo {
 }
 
 impl Dispute {
+    /// Create a new dispute for an order.
+    ///
+    /// The dispute starts in [`Status::Initiated`] with a fresh UUID, the
+    /// current timestamp as `created_at`, no solver assigned and `taken_at`
+    /// set to `0`. `order_status` should be the current status of the order
+    /// at the moment the dispute is filed; it is preserved in
+    /// `order_previous_status`.
     pub fn new(order_id: Uuid, order_status: String) -> Self {
         Self {
             id: Uuid::new_v4(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,110 +1,178 @@
+//! Error taxonomy used across the crate.
+//!
+//! Errors surfaced to clients are modelled as [`MostroError`], which is split
+//! into two branches:
+//!
+//! * [`MostroError::MostroCantDo`] — a "soft" error: the request was
+//!   well-formed but the server refuses to perform the action (e.g. the order
+//!   is not in the right state). Clients should surface the inner
+//!   [`CantDoReason`] to the user.
+//! * [`MostroError::MostroInternalErr`] — a "hard" error: something went
+//!   wrong while processing the request (database failure, Nostr relay
+//!   issue, malformed invoice, etc.). The inner [`ServiceError`] carries the
+//!   diagnostic detail.
+//!
+//! Both inner enums implement [`Display`](std::fmt::Display) with
+//! human-readable messages suited for logging.
+
 use crate::prelude::*;
 
-/// Represents specific reasons why a requested action cannot be performed
+/// Machine-readable reasons carried by a `CantDo` response.
+///
+/// Serialized in `snake_case` so clients can pattern-match on the value
+/// transported in [`crate::message::Payload::CantDo`].
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum CantDoReason {
-    /// The provided signature is invalid or missing
+    /// The provided signature is invalid or missing.
     InvalidSignature,
-    /// The specified trade index does not exist or is invalid
+    /// The specified trade index does not exist or is invalid.
     InvalidTradeIndex,
-    /// The provided amount is invalid or out of acceptable range
+    /// The provided amount is invalid or out of acceptable range.
     InvalidAmount,
-    /// The provided invoice is malformed or expired
+    /// The provided invoice is malformed or expired.
     InvalidInvoice,
-    /// The payment request is invalid or cannot be processed
+    /// The payment request is invalid or cannot be processed.
     InvalidPaymentRequest,
-    /// The specified peer is invalid or not found
+    /// The specified peer is invalid or not found.
     InvalidPeer,
-    /// The rating value is invalid or out of range
+    /// The rating value is invalid or out of range.
     InvalidRating,
-    /// The text message is invalid or contains prohibited content
+    /// The text message is invalid or contains prohibited content.
     InvalidTextMessage,
-    /// The order kind is invalid
+    /// The order kind is invalid.
     InvalidOrderKind,
-    /// The order status is invalid
+    /// The order status is invalid.
     InvalidOrderStatus,
-    /// Invalid pubkey
+    /// The provided public key is invalid.
     InvalidPubkey,
-    /// Invalid parameters
+    /// One or more request parameters are invalid.
     InvalidParameters,
-    /// The order is already canceled
+    /// The targeted order has already been canceled.
     OrderAlreadyCanceled,
-    /// Can't create user
+    /// User creation failed on the server side.
     CantCreateUser,
-    /// For users trying to do actions on orders that are not theirs
+    /// The caller tried to operate on an order that does not belong to them.
     IsNotYourOrder,
-    /// For users trying to do actions on orders not allowed by status
+    /// The requested action is not allowed in the order's current status.
     NotAllowedByStatus,
-    /// Fiat amount is out of range
+    /// The fiat amount is outside the allowed range for this order.
     OutOfRangeFiatAmount,
-    /// Sats amount is out of range
+    /// The sats amount is outside the allowed range for this order.
     OutOfRangeSatsAmount,
-    /// For users trying to do actions on dispute that are not theirs
+    /// The caller tried to operate on a dispute that does not belong to them.
     IsNotYourDispute,
-    /// For solvers when admin has taken over their dispute
+    /// A solver is being notified that an admin has taken over their dispute.
     DisputeTakenByAdmin,
-    /// For callers that are authenticated but do not have enough permissions
+    /// The caller is authenticated but lacks the permission for this action.
     NotAuthorized,
-    /// For users trying to create a dispute on an order that is not in dispute
+    /// A dispute could not be created (e.g. order not in a disputable state).
     DisputeCreationError,
-    /// Generic not found
+    /// Generic "resource not found" error.
     NotFound,
-    /// Invalid dispute status
+    /// The dispute is in an invalid state for the requested action.
     InvalidDisputeStatus,
-    /// Invalid action
+    /// The requested action is invalid.
     InvalidAction,
-    /// Pending order exists
+    /// The caller already has a pending order and cannot create another.
     PendingOrderExists,
-    /// Invalid fiat currency
+    /// The fiat currency code is not accepted by this Mostro node.
     InvalidFiatCurrency,
-    /// Too many requests
+    /// The caller is being rate-limited.
     TooManyRequests,
 }
 
+/// Internal errors raised by services behind the Mostro API.
+///
+/// Unlike [`CantDoReason`], values of this enum are not expected to be
+/// forwarded verbatim to end users; they are meant for logs, telemetry and
+/// other server-to-server diagnostics.
 #[derive(Debug, PartialEq, Eq)]
 pub enum ServiceError {
+    /// Wraps an error returned by `nostr_sdk`.
     NostrError(String),
+    /// The invoice string could not be parsed as a valid BOLT-11 invoice.
     ParsingInvoiceError,
+    /// A numeric value could not be parsed.
     ParsingNumberError,
+    /// The invoice has expired.
     InvoiceExpiredError,
+    /// The invoice is otherwise invalid.
     InvoiceInvalidError,
+    /// The invoice expiration time is below the minimum required.
     MinExpirationTimeError,
+    /// The invoice amount is below the minimum allowed.
     MinAmountError,
+    /// The invoice amount does not match the expected value.
     WrongAmountError,
+    /// The price API did not answer in time.
     NoAPIResponse,
+    /// The requested currency is not listed by the exchange API.
     NoCurrency,
+    /// The exchange API returned a response that could not be parsed.
     MalformedAPIRes,
+    /// Amount value is negative where only positives are allowed.
     NegativeAmount,
+    /// A Lightning Address could not be parsed.
     LnAddressParseError,
+    /// A Lightning Address payment was attempted with a wrong amount.
     LnAddressWrongAmount,
+    /// A Lightning payment failed; the inner string carries the reason.
     LnPaymentError(String),
+    /// Communication with the Lightning node failed.
     LnNodeError(String),
+    /// Order id was not found in the database.
     InvalidOrderId,
+    /// Database access failed; the inner string carries the detail.
     DbAccessError(String),
+    /// The provided public key is invalid.
     InvalidPubkey,
+    /// Hold-invoice operation failed; the inner string carries the detail.
     HoldInvoiceError(String),
+    /// Could not update the order status in the database.
     UpdateOrderStatusError,
+    /// The order status is invalid.
     InvalidOrderStatus,
+    /// The order kind is invalid.
     InvalidOrderKind,
+    /// A dispute already exists for this order.
     DisputeAlreadyExists,
+    /// Could not publish the dispute Nostr event.
     DisputeEventError,
+    /// The rating message itself is invalid.
     InvalidRating,
+    /// The rating value is outside the accepted range.
     InvalidRatingValue,
+    /// Failed to serialize or deserialize a [`crate::message::Message`].
     MessageSerializationError,
+    /// The dispute id is invalid or unknown.
     InvalidDisputeId,
+    /// The dispute status is invalid.
     InvalidDisputeStatus,
+    /// The payload does not match the action.
     InvalidPayload,
+    /// Any other unexpected error; inner string carries the detail.
     UnexpectedError(String),
+    /// An environment variable could not be read or parsed.
     EnvVarError(String),
+    /// Underlying I/O error.
     IOError(String),
+    /// NIP-44/NIP-59 encryption failed.
     EncryptionError(String),
+    /// NIP-44/NIP-59 decryption failed.
     DecryptionError(String),
 }
 
+/// Top-level error type returned by the Mostro API surface.
+///
+/// Most public functions in this crate return `Result<T, MostroError>`.
+/// Match on the variants to distinguish between user-actionable "can't do"
+/// responses and internal service errors.
 #[derive(Debug, PartialEq, Eq)]
 pub enum MostroError {
+    /// An internal service-level error; diagnostic only.
     MostroInternalErr(ServiceError),
+    /// A structured "can't do" response to surface to the user.
     MostroCantDo(CantDoReason),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,79 @@
+//! # Mostro Core
+//!
+//! `mostro-core` is the foundational library behind [Mostro](https://mostro.network),
+//! a peer-to-peer Bitcoin/Lightning over Nostr marketplace. It contains the
+//! protocol-level data types (orders, disputes, users, ratings and messages)
+//! shared between the Mostro daemon and any client, together with the NIP-59
+//! GiftWrap transport used to exchange them privately.
+//!
+//! ## Overview
+//!
+//! A typical Mostro flow involves two peers (a buyer and a seller) and a
+//! Mostro node that coordinates the trade. All protocol-level communication is
+//! expressed through [`message::Message`] values that travel inside encrypted
+//! NIP-59 envelopes built by [`nip59::wrap_message`]. The receiver uses
+//! [`nip59::unwrap_message`] to recover the original [`message::Message`] and,
+//! optionally, the sender's signature.
+//!
+//! Persistent state (orders, disputes, users) is modelled by the [`order`],
+//! [`dispute`] and [`user`] modules. They can optionally derive the
+//! [`sqlx::FromRow`] and `sqlx_crud::SqlxCrud` traits by enabling the
+//! `sqlx` feature.
+//!
+//! ## Quick start
+//!
+//! The [`prelude`] module re-exports the most commonly used types:
+//!
+//! ```
+//! use mostro_core::prelude::*;
+//!
+//! let order = SmallOrder::new(
+//!     None,
+//!     Some(Kind::Sell),
+//!     Some(Status::Pending),
+//!     100,
+//!     "eur".to_string(),
+//!     None,
+//!     None,
+//!     100,
+//!     "SEPA".to_string(),
+//!     1,
+//!     None,
+//!     None,
+//!     None,
+//!     None,
+//!     None,
+//! );
+//! let message = Message::new_order(None, Some(1), Some(2), Action::NewOrder, Some(Payload::Order(order)));
+//! assert!(message.verify());
+//! ```
+//!
+//! ## Cargo features
+//!
+//! * `wasm` *(default)* — enables `wasm-bindgen` annotations on selected types
+//!   so the crate can be used from JavaScript/WebAssembly contexts.
+//! * `sqlx` — derives `FromRow` and `SqlxCrud` for the persistent structs
+//!   (`Order`, `User`, `Dispute`, `RestoredOrderHelper`, …). Implies `wasm`.
+//!
+//! ## Module map
+//!
+//! * [`message`] — protocol message envelope, actions and payloads.
+//! * [`order`] — order types, states and helpers.
+//! * [`dispute`] — dispute types and states.
+//! * [`user`] — persistent user representation and rating updates.
+//! * [`rating`] — Nostr-tag-encoded reputation helper.
+//! * [`error`] — unified error taxonomy ([`MostroError`], [`ServiceError`],
+//!   [`CantDoReason`]).
+//! * [`nip59`] — GiftWrap wrap/unwrap transport.
+//! * [`prelude`] — convenience re-exports.
+//!
+//! [`MostroError`]: crate::error::MostroError
+//! [`ServiceError`]: crate::error::ServiceError
+//! [`CantDoReason`]: crate::error::CantDoReason
+
+#![doc(html_root_url = "https://docs.rs/mostro-core")]
+#![warn(missing_docs)]
+
 pub mod dispute;
 pub mod error;
 pub mod message;

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,3 +1,15 @@
+//! Protocol message envelope exchanged between clients and a Mostro node.
+//!
+//! The top-level type is [`Message`], a tagged union that carries a
+//! [`MessageKind`] together with a discriminator (order, dispute, DM, rate,
+//! can't-do, restore). [`MessageKind`] holds the shared fields present on
+//! every request/response: protocol version, optional identifier, trade
+//! index, [`Action`] and [`Payload`].
+//!
+//! In transit, messages are serialized to JSON, optionally signed with the
+//! sender's trade keys using [`Message::sign`], and wrapped in a NIP-59
+//! envelope by [`crate::nip59::wrap_message`].
+
 use crate::prelude::*;
 use bitcoin::hashes::sha256::Hash as Sha256Hash;
 use bitcoin::hashes::Hash;
@@ -12,73 +24,137 @@ use sqlx_crud::SqlxCrud;
 use std::fmt;
 use uuid::Uuid;
 
-/// One party of the trade
+/// Identity of a counterpart in a trade.
+///
+/// `Peer` bundles the counterpart's trade public key with an optional
+/// [`UserInfo`] snapshot so it can be embedded into messages that need to
+/// surface reputation (for example the peer disclosure sent with
+/// [`Action::FiatSentOk`]).
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Peer {
+    /// Trade public key of the peer (hex or npub).
     pub pubkey: String,
+    /// Optional reputation snapshot. Absent when the peer operates in full
+    /// privacy mode.
     pub reputation: Option<UserInfo>,
 }
 
 impl Peer {
+    /// Create a new [`Peer`].
     pub fn new(pubkey: String, reputation: Option<UserInfo>) -> Self {
         Self { pubkey, reputation }
     }
 
+    /// Parse a [`Peer`] from its JSON representation.
     pub fn from_json(json: &str) -> Result<Self, ServiceError> {
         serde_json::from_str(json).map_err(|_| ServiceError::MessageSerializationError)
     }
 
+    /// Serialize the peer to a JSON string.
     pub fn as_json(&self) -> Result<String, ServiceError> {
         serde_json::to_string(&self).map_err(|_| ServiceError::MessageSerializationError)
     }
 }
 
-/// Action is used to identify each message between Mostro and users
+/// Discriminator describing the verb of a Mostro message.
+///
+/// `Action` values are serialized in `kebab-case`. Each action has its own
+/// expected [`Payload`] shape — see [`MessageKind::verify`] for the full
+/// matrix.
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub enum Action {
+    /// Publish a new order. Payload: [`Payload::Order`].
     NewOrder,
+    /// Take an existing `sell` order. Payload: optional
+    /// [`Payload::PaymentRequest`] or [`Payload::Amount`].
     TakeSell,
+    /// Take an existing `buy` order. Payload: optional [`Payload::Amount`].
     TakeBuy,
+    /// Request the taker to pay a Lightning invoice.
+    /// Payload: [`Payload::PaymentRequest`].
     PayInvoice,
+    /// Buyer notifies Mostro that fiat was sent.
     FiatSent,
+    /// Mostro acknowledges the fiat-sent notification to the seller.
     FiatSentOk,
+    /// Seller releases the hold invoice funds.
     Release,
+    /// Mostro confirms that the funds have been released.
     Released,
+    /// Cancel an order.
     Cancel,
+    /// Mostro confirms that the order was canceled.
     Canceled,
+    /// Local side started a cooperative cancel.
     CooperativeCancelInitiatedByYou,
+    /// Remote side started a cooperative cancel.
     CooperativeCancelInitiatedByPeer,
+    /// Local side opened a dispute.
     DisputeInitiatedByYou,
+    /// Remote side opened a dispute.
     DisputeInitiatedByPeer,
+    /// Both sides agreed on the cooperative cancel.
     CooperativeCancelAccepted,
+    /// Mostro accepted the buyer's payout invoice.
     BuyerInvoiceAccepted,
+    /// Trade completed successfully.
     PurchaseCompleted,
+    /// Mostro saw the hold-invoice payment accepted by the node.
     HoldInvoicePaymentAccepted,
+    /// Mostro saw the hold-invoice payment settled.
     HoldInvoicePaymentSettled,
+    /// Mostro saw the hold-invoice payment canceled.
     HoldInvoicePaymentCanceled,
+    /// Informational: waiting for the seller to pay the hold invoice.
     WaitingSellerToPay,
+    /// Informational: waiting for the buyer's payout invoice.
     WaitingBuyerInvoice,
+    /// Buyer sends/updates its payout invoice.
+    /// Payload: [`Payload::PaymentRequest`].
     AddInvoice,
+    /// Informational: a buyer has taken a sell order.
     BuyerTookOrder,
+    /// Server-initiated rating request.
     Rate,
+    /// Client-initiated rate. Payload: [`Payload::RatingUser`].
     RateUser,
+    /// Acknowledgement of a received rating.
     RateReceived,
+    /// Mostro returns a structured refusal. Payload: [`Payload::CantDo`].
     CantDo,
+    /// Client-initiated dispute.
     Dispute,
+    /// Admin cancels a trade.
     AdminCancel,
+    /// Admin cancel acknowledged.
     AdminCanceled,
+    /// Admin settles the hold invoice.
     AdminSettle,
+    /// Admin settle acknowledged.
     AdminSettled,
+    /// Admin registers a new dispute solver.
     AdminAddSolver,
+    /// Solver takes a dispute.
     AdminTakeDispute,
+    /// Solver took the dispute acknowledged.
     AdminTookDispute,
+    /// Notification that a Lightning payment failed.
+    /// Payload: [`Payload::PaymentFailed`].
     PaymentFailed,
+    /// Invoice associated with the order was updated.
     InvoiceUpdated,
+    /// Direct message between users. Payload: [`Payload::TextMessage`].
     SendDm,
+    /// Disclosure of a counterpart's trade pubkey. Payload: [`Payload::Peer`].
     TradePubkey,
+    /// Client asks Mostro to restore its session state. Payload must be `None`.
     RestoreSession,
+    /// Client asks Mostro for its last known trade index. Payload must be
+    /// `None`.
     LastTradeIndex,
+    /// Listing of orders in response to a query.
+    /// Payload: [`Payload::Ids`] or [`Payload::Orders`].
     Orders,
 }
 
@@ -88,20 +164,32 @@ impl fmt::Display for Action {
     }
 }
 
-/// Use this Message to establish communication between users and Mostro
+/// Top-level Mostro message exchanged between users and Mostro.
+///
+/// `Message` is a tagged union: every variant carries the shared
+/// [`MessageKind`] body, while the variant itself tells the receiver which
+/// channel the message belongs to (orders, disputes, DMs, rating, can't-do,
+/// session restore). Serializes as `kebab-case` JSON.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum Message {
+    /// Order-channel message.
     Order(MessageKind),
+    /// Dispute-channel message.
     Dispute(MessageKind),
+    /// "Can't do" response returned by the Mostro node.
     CantDo(MessageKind),
+    /// Rating message (server-initiated rate request or client rate).
     Rate(MessageKind),
+    /// Direct message between users.
     Dm(MessageKind),
+    /// Session restore request/response.
     Restore(MessageKind),
 }
 
 impl Message {
-    /// New order message
+    /// Build a new `Message::Order` wrapping a freshly constructed
+    /// [`MessageKind`].
     pub fn new_order(
         id: Option<Uuid>,
         request_id: Option<u64>,
@@ -113,7 +201,8 @@ impl Message {
         Self::Order(kind)
     }
 
-    /// New dispute message
+    /// Build a new `Message::Dispute` wrapping a freshly constructed
+    /// [`MessageKind`].
     pub fn new_dispute(
         id: Option<Uuid>,
         request_id: Option<u64>,
@@ -126,19 +215,24 @@ impl Message {
         Self::Dispute(kind)
     }
 
+    /// Build a new `Message::Restore` with [`Action::RestoreSession`].
+    ///
+    /// According to [`MessageKind::verify`], the payload for a restore
+    /// request must be `None`. Any other payload yields an invalid message.
     pub fn new_restore(payload: Option<Payload>) -> Self {
         let kind = MessageKind::new(None, None, None, Action::RestoreSession, payload);
         Self::Restore(kind)
     }
 
-    /// New can't do template message message
+    /// Build a new `Message::CantDo` message (a structured refusal sent by
+    /// Mostro when a request cannot be fulfilled).
     pub fn cant_do(id: Option<Uuid>, request_id: Option<u64>, payload: Option<Payload>) -> Self {
         let kind = MessageKind::new(id, request_id, None, Action::CantDo, payload);
 
         Self::CantDo(kind)
     }
 
-    /// New DM message
+    /// Build a new `Message::Dm` carrying a direct message between users.
     pub fn new_dm(
         id: Option<Uuid>,
         request_id: Option<u64>,
@@ -150,17 +244,17 @@ impl Message {
         Self::Dm(kind)
     }
 
-    /// Get message from json string
+    /// Parse a [`Message`] from its JSON representation.
     pub fn from_json(json: &str) -> Result<Self, ServiceError> {
         serde_json::from_str(json).map_err(|_| ServiceError::MessageSerializationError)
     }
 
-    /// Get message as json string
+    /// Serialize the message to a JSON string.
     pub fn as_json(&self) -> Result<String, ServiceError> {
         serde_json::to_string(&self).map_err(|_| ServiceError::MessageSerializationError)
     }
 
-    // Get inner message kind
+    /// Borrow the inner [`MessageKind`] regardless of the variant.
     pub fn get_inner_message_kind(&self) -> &MessageKind {
         match self {
             Message::Dispute(k)
@@ -172,7 +266,10 @@ impl Message {
         }
     }
 
-    // Get action from the inner message
+    /// Return the [`Action`] of the inner [`MessageKind`].
+    ///
+    /// Always returns `Some` for the current variant set; the `Option` is
+    /// kept for API stability.
     pub fn inner_action(&self) -> Option<Action> {
         match self {
             Message::Dispute(a)
@@ -184,7 +281,8 @@ impl Message {
         }
     }
 
-    /// Verify if is valid the inner message
+    /// Validate that the inner [`MessageKind`] is consistent with its
+    /// [`Action`]. Delegates to [`MessageKind::verify`].
     pub fn verify(&self) -> bool {
         match self {
             Message::Order(m)
@@ -196,6 +294,14 @@ impl Message {
         }
     }
 
+    /// Produce a Schnorr signature over the SHA-256 digest of `message`
+    /// using `keys`.
+    ///
+    /// This is the signature embedded in the rumor tuple when
+    /// [`crate::nip59::wrap_message`] is called with
+    /// [`WrapOptions::signed`](crate::nip59::WrapOptions::signed) set to
+    /// `true`. It binds a message to the sender's trade keys without
+    /// relying on the outer Nostr event signature.
     pub fn sign(message: String, keys: &Keys) -> Signature {
         let hash: Sha256Hash = Sha256Hash::hash(message.as_bytes());
         let hash = hash.to_byte_array();
@@ -204,6 +310,11 @@ impl Message {
         keys.sign_schnorr(&message)
     }
 
+    /// Verify a signature previously produced by [`Message::sign`].
+    ///
+    /// Returns `true` when `sig` is a valid Schnorr signature of the
+    /// SHA-256 digest of `message` under `pubkey`, `false` otherwise
+    /// (including when `pubkey` has no x-only representation).
     pub fn verify_signature(message: String, pubkey: PublicKey, sig: Signature) -> bool {
         // Create payload hash
         let hash: Sha256Hash = Sha256Hash::hash(message.as_bytes());
@@ -221,158 +332,208 @@ impl Message {
     }
 }
 
-/// Use this Message to establish communication between users and Mostro
+/// Body shared by every [`Message`] variant.
+///
+/// All Mostro protocol messages share this envelope: a protocol version,
+/// an optional client-chosen request id for correlation, a trade index used
+/// to enforce strictly increasing sequences per user, an optional
+/// order/dispute id, an [`Action`] and an optional [`Payload`].
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct MessageKind {
-    /// Message version
+    /// Mostro protocol version. Set to
+    /// `PROTOCOL_VER` by [`MessageKind::new`].
     pub version: u8,
-    /// Request_id for test on client
+    /// Client-chosen correlation id, echoed back on responses so the client
+    /// can match them to in-flight requests.
     pub request_id: Option<u64>,
-    /// Trade key index
+    /// Trade index attached to this message. Must be strictly greater than
+    /// the last trade index Mostro has seen for the sender.
     pub trade_index: Option<i64>,
-    /// Message id is not mandatory
+    /// Optional target identifier (usually the id of an [`crate::order::Order`]
+    /// or [`crate::dispute::Dispute`]).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<Uuid>,
-    /// Action to be taken
+    /// Verb of the message.
     pub action: Action,
-    /// Payload of the Message
+    /// Payload attached to the action. The allowed shape for a given action
+    /// is enforced by [`MessageKind::verify`].
     pub payload: Option<Payload>,
 }
 
+/// Alias for a signed integer amount in satoshis.
 type Amount = i64;
 
-/// Payment failure retry information
+/// Retry configuration for a failed Lightning payment.
+///
+/// Sent inside a [`Payload::PaymentFailed`] so the client knows how many
+/// retries to expect and how long to wait between them.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PaymentFailedInfo {
-    /// Maximum number of payment attempts
+    /// Maximum number of payment attempts Mostro will perform.
     pub payment_attempts: u32,
-    /// Retry interval in seconds between payment attempts
+    /// Delay in seconds between two retry attempts.
     pub payment_retries_interval: u32,
 }
 
-/// Helper struct for faster order-restore queries (used by mostrod).
-/// Intended as a lightweight row-mapper when fetching restore metadata.
+/// Row-mapper used by `mostrod` when fetching metadata for session restore.
+///
+/// Not intended as a general-purpose order representation — field names are
+/// chosen to match the SQL `SELECT` aliases used by the server query.
 #[cfg_attr(feature = "sqlx", derive(FromRow, SqlxCrud))]
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct RestoredOrderHelper {
+    /// Order id.
     pub id: Uuid,
+    /// Order status, serialized as kebab-case.
     pub status: String,
+    /// Master identity pubkey of the buyer, if any.
     pub master_buyer_pubkey: Option<String>,
+    /// Master identity pubkey of the seller, if any.
     pub master_seller_pubkey: Option<String>,
+    /// Trade index the buyer used on this order.
     pub trade_index_buyer: Option<i64>,
+    /// Trade index the seller used on this order.
     pub trade_index_seller: Option<i64>,
 }
 
-/// Information about the dispute to be restored in the new client.
-/// Note: field names are chosen to match expected SQL SELECT aliases in mostrod (e.g. `status` aliased as `dispute_status`).
+/// Row-mapper used by `mostrod` when fetching disputes for session restore.
+///
+/// Field names are chosen to match the SQL `SELECT` aliases in the restore
+/// query (in particular `status` is aliased as `dispute_status`).
 #[cfg_attr(feature = "sqlx", derive(FromRow, SqlxCrud))]
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct RestoredDisputeHelper {
+    /// Dispute id.
     pub dispute_id: Uuid,
+    /// Order id the dispute is attached to.
     pub order_id: Uuid,
+    /// Dispute status, serialized as kebab-case.
     pub dispute_status: String,
+    /// Master identity pubkey of the buyer, if any.
     pub master_buyer_pubkey: Option<String>,
+    /// Master identity pubkey of the seller, if any.
     pub master_seller_pubkey: Option<String>,
+    /// Trade index the buyer used on the parent order.
     pub trade_index_buyer: Option<i64>,
+    /// Trade index the seller used on the parent order.
     pub trade_index_seller: Option<i64>,
-    /// Indicates whether the buyer has initiated a dispute for this order.
-    /// Used in conjunction with `seller_dispute` to derive the `initiator` field in `RestoredDisputesInfo`.
+    /// Whether the buyer has initiated a dispute for this order.
+    /// Combined with [`Self::seller_dispute`] to derive
+    /// [`RestoredDisputesInfo::initiator`].
     pub buyer_dispute: bool,
-    /// Indicates whether the seller has initiated a dispute for this order.
-    /// Used in conjunction with `buyer_dispute` to derive the `initiator` field in `RestoredDisputesInfo`.
+    /// Whether the seller has initiated a dispute for this order.
+    /// Combined with [`Self::buyer_dispute`] to derive
+    /// [`RestoredDisputesInfo::initiator`].
     pub seller_dispute: bool,
-    /// Public key of the solver assigned to the dispute, None if no solver has taken it.
+    /// Public key of the solver assigned to the dispute, `None` if no
+    /// solver has taken it.
     pub solver_pubkey: Option<String>,
 }
 
-/// Information about the order to be restored in the new client
+/// Minimal per-order information returned to a client on session restore.
 #[cfg_attr(feature = "sqlx", derive(FromRow, SqlxCrud))]
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct RestoredOrdersInfo {
-    /// Id of the order
+    /// Id of the order.
     pub order_id: Uuid,
-    /// Trade index of the order
+    /// Trade index of the order as seen by the requesting user.
     pub trade_index: i64,
-    /// Status of the order
+    /// Current status of the order, serialized as kebab-case.
     pub status: String,
 }
 
-/// Enum representing who initiated a dispute
+/// Identifies which party of an order opened a dispute.
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "sqlx", sqlx(type_name = "TEXT", rename_all = "lowercase"))]
 pub enum DisputeInitiator {
+    /// The buyer opened the dispute.
     Buyer,
+    /// The seller opened the dispute.
     Seller,
 }
 
-/// Information about the dispute to be restored in the new client
+/// Minimal per-dispute information returned to a client on session restore.
 #[cfg_attr(feature = "sqlx", derive(FromRow, SqlxCrud))]
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct RestoredDisputesInfo {
-    /// Id of the dispute
+    /// Id of the dispute.
     pub dispute_id: Uuid,
-    /// Order id of the dispute
+    /// Id of the order the dispute is attached to.
     pub order_id: Uuid,
-    /// Trade index of the dispute
+    /// Trade index of the dispute as seen by the requesting user.
     pub trade_index: i64,
-    /// Status of the dispute
+    /// Current status of the dispute, serialized as kebab-case.
     pub status: String,
-    /// Who initiated the dispute: Buyer, Seller, or null if unknown
+    /// Who initiated the dispute: [`DisputeInitiator::Buyer`],
+    /// [`DisputeInitiator::Seller`], or `None` when unknown.
     pub initiator: Option<DisputeInitiator>,
-    /// Public key of the solver assigned to the dispute, None if no solver has taken it yet
+    /// Public key of the solver assigned to the dispute, `None` if no
+    /// solver has taken it yet.
     pub solver_pubkey: Option<String>,
 }
 
-/// Restore session user info
+/// Bundle of orders and disputes returned on a session restore.
+///
+/// Carried inside [`Payload::RestoreData`]. The server typically sends this
+/// struct in the response to a [`Action::RestoreSession`] request.
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct RestoreSessionInfo {
-    /// Vector of orders of the user requesting the restore of data
+    /// Orders associated with the requesting user.
     #[serde(rename = "orders")]
     pub restore_orders: Vec<RestoredOrdersInfo>,
-    /// Vector of disputes of the user requesting the restore of data
+    /// Disputes associated with the requesting user.
     #[serde(rename = "disputes")]
     pub restore_disputes: Vec<RestoredDisputesInfo>,
 }
 
-/// Message payload
+/// Typed payload attached to a [`MessageKind`].
+///
+/// Each variant corresponds to a set of [`Action`] values that can legally
+/// carry it (see [`MessageKind::verify`]). Serialized in `snake_case` so
+/// that the variant name is the JSON discriminator.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum Payload {
-    /// Order
+    /// A compact representation of an order used by [`Action::NewOrder`].
     Order(SmallOrder),
-    /// Payment request
+    /// Lightning payment request plus optional amount override.
+    ///
+    /// Used by [`Action::PayInvoice`], [`Action::AddInvoice`] and
+    /// [`Action::TakeSell`]. The [`SmallOrder`] carries the matching order
+    /// when relevant; the `String` is a BOLT-11 invoice.
     PaymentRequest(Option<SmallOrder>, String, Option<Amount>),
-    /// Use to send a message to another user
+    /// Free-form text message used by DMs.
     TextMessage(String),
-    /// Peer information
+    /// Peer disclosure (trade pubkey and optional reputation).
     Peer(Peer),
-    /// Used to rate a user
+    /// Rating value the user wants to attach to a completed trade.
     RatingUser(u8),
-    /// In some cases we need to send an amount
+    /// Raw amount in satoshis (for actions that accept an amount override).
     Amount(Amount),
-    /// Dispute
+    /// Dispute context: the dispute id plus optional
+    /// [`SolverDisputeInfo`] bundle sent to solvers.
     Dispute(Uuid, Option<SolverDisputeInfo>),
-    /// Here the reason why we can't do the action
+    /// Reason carried by a [`Action::CantDo`] response.
     CantDo(Option<CantDoReason>),
-    /// This is used by the maker of a range order only on
-    /// messages with action release and fiat-sent
-    /// to inform the next trade pubkey and trade index
+    /// Next trade key and index announced by the maker of a range order
+    /// when it emits [`Action::Release`] or [`Action::FiatSent`].
     NextTrade(String, u32),
-    /// Payment failure retry configuration information
+    /// Retry configuration surfaced by [`Action::PaymentFailed`].
     PaymentFailed(PaymentFailedInfo),
-    /// Restore session data with orders and disputes
+    /// Payload returned by the server on a session restore.
     RestoreData(RestoreSessionInfo),
-    /// IDs array
+    /// Vector of order ids (lightweight listing).
     Ids(Vec<Uuid>),
-    /// Orders array
+    /// Vector of [`SmallOrder`] values (full listing).
     Orders(Vec<SmallOrder>),
 }
 
 #[allow(dead_code)]
 impl MessageKind {
-    /// New message
+    /// Build a new [`MessageKind`] stamped with the current protocol
+    /// version (`PROTOCOL_VER`).
     pub fn new(
         id: Option<Uuid>,
         request_id: Option<u64>,
@@ -389,21 +550,26 @@ impl MessageKind {
             payload,
         }
     }
-    /// Get message from json string
+    /// Parse a [`MessageKind`] from its JSON representation.
     pub fn from_json(json: &str) -> Result<Self, ServiceError> {
         serde_json::from_str(json).map_err(|_| ServiceError::MessageSerializationError)
     }
-    /// Get message as json string
+    /// Serialize the [`MessageKind`] to a JSON string.
     pub fn as_json(&self) -> Result<String, ServiceError> {
         serde_json::to_string(&self).map_err(|_| ServiceError::MessageSerializationError)
     }
 
-    // Get action from the inner message
+    /// Return a clone of the [`Action`] carried by this message.
     pub fn get_action(&self) -> Action {
         self.action.clone()
     }
 
-    /// Get the next trade keys when order is settled
+    /// Extract the `(next_trade_pubkey, next_trade_index)` pair from a
+    /// [`Payload::NextTrade`] payload.
+    ///
+    /// Returns `Ok(None)` when there is no payload at all and
+    /// [`ServiceError::InvalidPayload`] when the payload is present but of
+    /// a different variant.
     pub fn get_next_trade_key(&self) -> Result<Option<(String, u32)>, ServiceError> {
         match &self.payload {
             Some(Payload::NextTrade(key, index)) => Ok(Some((key.to_string(), *index))),
@@ -412,6 +578,13 @@ impl MessageKind {
         }
     }
 
+    /// Extract the rating value from a [`Payload::RatingUser`] payload,
+    /// validating it against
+    /// [`MIN_RATING`]`..=`[`MAX_RATING`].
+    ///
+    /// Returns [`ServiceError::InvalidRating`] when the payload shape is
+    /// wrong and [`ServiceError::InvalidRatingValue`] when the value is out
+    /// of range.
     pub fn get_rating(&self) -> Result<u8, ServiceError> {
         if let Some(Payload::RatingUser(v)) = self.payload.to_owned() {
             if !(MIN_RATING..=MAX_RATING).contains(&v) {
@@ -423,7 +596,12 @@ impl MessageKind {
         }
     }
 
-    /// Verify if is valid message
+    /// Check that the payload, id and trade index are consistent with the
+    /// action carried by this message.
+    ///
+    /// Returns `true` when the combination is well-formed and `false`
+    /// otherwise; Mostro uses this method to reject malformed requests
+    /// before processing them.
     pub fn verify(&self) -> bool {
         match &self.action {
             Action::NewOrder => matches!(&self.payload, Some(Payload::Order(_))),
@@ -494,6 +672,10 @@ impl MessageKind {
         }
     }
 
+    /// Return the [`SmallOrder`] carried by a [`Action::NewOrder`] message.
+    ///
+    /// Yields `None` if the action is not `NewOrder` or the payload is of a
+    /// different variant.
     pub fn get_order(&self) -> Option<&SmallOrder> {
         if self.action != Action::NewOrder {
             return None;
@@ -504,6 +686,11 @@ impl MessageKind {
         }
     }
 
+    /// Return the Lightning payment request embedded in a message.
+    ///
+    /// Valid only for [`Action::TakeSell`], [`Action::AddInvoice`] and
+    /// [`Action::NewOrder`]. For `NewOrder`, the invoice is read from the
+    /// [`SmallOrder::buyer_invoice`] field. Returns `None` otherwise.
     pub fn get_payment_request(&self) -> Option<String> {
         if self.action != Action::TakeSell
             && self.action != Action::AddInvoice
@@ -518,6 +705,9 @@ impl MessageKind {
         }
     }
 
+    /// Return the amount override embedded in a [`Action::TakeSell`] or
+    /// [`Action::TakeBuy`] message, either from a [`Payload::Amount`] or
+    /// from the third element of a [`Payload::PaymentRequest`].
     pub fn get_amount(&self) -> Option<Amount> {
         if self.action != Action::TakeSell && self.action != Action::TakeBuy {
             return None;
@@ -529,10 +719,13 @@ impl MessageKind {
         }
     }
 
+    /// Borrow the optional payload.
     pub fn get_payload(&self) -> Option<&Payload> {
         self.payload.as_ref()
     }
 
+    /// Return `(true, index)` when the message carries a trade index,
+    /// `(false, 0)` otherwise.
     pub fn has_trade_index(&self) -> (bool, i64) {
         if let Some(index) = self.trade_index {
             return (true, index);
@@ -540,6 +733,7 @@ impl MessageKind {
         (false, 0)
     }
 
+    /// Return the trade index carried by the message, or `0` when absent.
     pub fn trade_index(&self) -> i64 {
         if let Some(index) = self.trade_index {
             return index;

--- a/src/order.rs
+++ b/src/order.rs
@@ -1,3 +1,12 @@
+//! Orders and their lifecycle.
+//!
+//! [`Order`] is the database-backed record for a trade between a buyer and a
+//! seller on Mostro. Orders have a [`Kind`] (buy or sell) and a [`Status`]
+//! that evolves through a small state machine as the trade progresses.
+//!
+//! [`SmallOrder`] is a compact, wire-friendly view of an order used when
+//! broadcasting via Nostr or surfacing minimal information to clients.
+
 use crate::prelude::*;
 use nostr_sdk::{PublicKey, Timestamp};
 use serde::{Deserialize, Serialize};
@@ -9,18 +18,23 @@ use std::{fmt::Display, str::FromStr};
 use uuid::Uuid;
 use wasm_bindgen::prelude::*;
 
-/// Orders can be only Buy or Sell
+/// Direction of an order: the maker wants to buy or sell sats.
 #[wasm_bindgen]
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum Kind {
+    /// The maker wants to buy sats in exchange for fiat.
     Buy,
+    /// The maker wants to sell sats in exchange for fiat.
     Sell,
 }
 
 impl FromStr for Kind {
     type Err = ();
 
+    /// Parse a [`Kind`] from `"buy"` or `"sell"` (case-insensitive).
+    ///
+    /// Returns `Err(())` for any other input.
     fn from_str(kind: &str) -> std::result::Result<Self, Self::Err> {
         match kind.to_lowercase().as_str() {
             "buy" => std::result::Result::Ok(Self::Buy),
@@ -39,25 +53,43 @@ impl Display for Kind {
     }
 }
 
-/// Each status that an order can have
+/// Lifecycle status of an [`Order`].
+///
+/// Values are serialized in `kebab-case`, matching the representation stored
+/// in the database and sent over the wire.
 #[wasm_bindgen]
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum Status {
+    /// Order is published and available to be taken.
     Active,
+    /// Order was canceled by the maker or the taker.
     Canceled,
+    /// Order was canceled by an admin.
     CanceledByAdmin,
+    /// Order was settled by an admin (solver) after a dispute.
     SettledByAdmin,
+    /// Order was completed by an admin after a dispute.
     CompletedByAdmin,
+    /// Order is currently in dispute.
     Dispute,
+    /// Order expired before being taken or completed.
     Expired,
+    /// Buyer has marked fiat as sent; waiting for the seller to release.
     FiatSent,
+    /// Hold invoice has been settled; payment to the buyer is in flight.
     SettledHoldInvoice,
+    /// Order has been created but not yet published.
     Pending,
+    /// Trade completed successfully.
     Success,
+    /// Waiting for the buyer's payout invoice.
     WaitingBuyerInvoice,
+    /// Waiting for the seller to pay the hold invoice.
     WaitingPayment,
+    /// Both parties agreed to cooperatively cancel the trade.
     CooperativelyCanceled,
+    /// Order has been taken and the trade is in progress.
     InProgress,
 }
 
@@ -107,52 +139,107 @@ impl FromStr for Status {
         }
     }
 }
-/// Database representation of an order
+/// Persistent representation of a Mostro order.
+///
+/// This is the canonical on-disk record kept by a Mostro node. All fields
+/// are stored so an order can be recomputed / restarted from its row alone;
+/// clients usually work with the lighter [`SmallOrder`] view.
+///
+/// Timestamps are Unix seconds; `hash` / `preimage` refer to the hold
+/// invoice used to lock the seller's funds.
 #[cfg_attr(feature = "sqlx", derive(FromRow, SqlxCrud), external_id)]
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 pub struct Order {
+    /// Unique order identifier.
     pub id: Uuid,
+    /// Order kind ([`Kind::Buy`] or [`Kind::Sell`]), serialized as
+    /// kebab-case.
     pub kind: String,
+    /// Nostr event id of the order publication.
     pub event_id: String,
+    /// Payment hash of the seller's hold invoice, once generated.
     pub hash: Option<String>,
+    /// Preimage revealed when the hold invoice is settled.
     pub preimage: Option<String>,
+    /// Trade public key of the order creator (maker).
     pub creator_pubkey: String,
+    /// Trade public key of the party who initiated a cancel, if any.
     pub cancel_initiator_pubkey: Option<String>,
+    /// Buyer trade public key.
     pub buyer_pubkey: Option<String>,
+    /// Buyer master identity pubkey. Equal to `buyer_pubkey` when the
+    /// buyer operates in full-privacy mode.
     pub master_buyer_pubkey: Option<String>,
+    /// Seller trade public key.
     pub seller_pubkey: Option<String>,
+    /// Seller master identity pubkey. Equal to `seller_pubkey` when the
+    /// seller operates in full-privacy mode.
     pub master_seller_pubkey: Option<String>,
+    /// Current [`Status`] of the order, serialized as kebab-case.
     pub status: String,
+    /// `true` if the sats amount was computed from a live market price.
     pub price_from_api: bool,
+    /// Premium percentage applied on top of the spot price.
     pub premium: i64,
+    /// Free-form payment method description (e.g. "SEPA,Bank transfer").
     pub payment_method: String,
+    /// Sats amount. `0` means the amount is computed at take-time from the
+    /// fiat amount and the current market price.
     pub amount: i64,
+    /// Lower bound of a range order (fiat amount). `None` for fixed orders.
     pub min_amount: Option<i64>,
+    /// Upper bound of a range order (fiat amount). `None` for fixed orders.
     pub max_amount: Option<i64>,
+    /// `true` when the buyer has initiated a dispute on this order.
     pub buyer_dispute: bool,
+    /// `true` when the seller has initiated a dispute on this order.
     pub seller_dispute: bool,
+    /// `true` when the buyer has initiated a cooperative cancel.
     pub buyer_cooperativecancel: bool,
+    /// `true` when the seller has initiated a cooperative cancel.
     pub seller_cooperativecancel: bool,
+    /// Mostro fee charged for this trade, in sats.
     pub fee: i64,
+    /// Lightning routing fee observed when paying the buyer.
     pub routing_fee: i64,
+    /// Optional developer-fee portion of `fee`.
     pub dev_fee: i64,
+    /// `true` once the developer fee has been paid out.
     pub dev_fee_paid: bool,
+    /// Payment hash of the developer-fee payment, when available.
     pub dev_fee_payment_hash: Option<String>,
+    /// Fiat currency code (e.g. "EUR", "USD").
     pub fiat_code: String,
+    /// Fiat amount of the trade.
     pub fiat_amount: i64,
+    /// Buyer's Lightning payout invoice, once provided.
     pub buyer_invoice: Option<String>,
+    /// Parent order id for orders derived from a range parent.
     pub range_parent_id: Option<Uuid>,
+    /// Unix timestamp (seconds) when the hold invoice was locked in.
     pub invoice_held_at: i64,
+    /// Unix timestamp (seconds) when the order was taken.
     pub taken_at: i64,
+    /// Unix timestamp (seconds) when the order was created.
     pub created_at: i64,
+    /// `true` once the buyer has rated the counterpart.
     pub buyer_sent_rate: bool,
+    /// `true` once the seller has rated the counterpart.
     pub seller_sent_rate: bool,
+    /// `true` if the latest payment attempt to the buyer failed.
     pub failed_payment: bool,
+    /// Number of payment attempts performed so far.
     pub payment_attempts: i64,
+    /// Unix timestamp (seconds) when the order expires automatically.
     pub expires_at: i64,
+    /// Trade index used by the seller when creating / taking the order.
     pub trade_index_seller: Option<i64>,
+    /// Trade index used by the buyer when creating / taking the order.
     pub trade_index_buyer: Option<i64>,
+    /// Trade public key announced by a range-order maker for the next
+    /// trade in the same range.
     pub next_trade_pubkey: Option<String>,
+    /// Trade index announced by a range-order maker for the next trade.
     pub next_trade_index: Option<i64>,
 }
 
@@ -193,7 +280,11 @@ impl From<SmallOrder> for Order {
 }
 
 impl Order {
-    /// Convert an order to a small order
+    /// Build a [`SmallOrder`] suitable for broadcasting as a new order event.
+    ///
+    /// Copies the tradable fields (amounts, payment method, premium, etc.)
+    /// from `self`. Trade pubkeys are left unset because a new order is
+    /// published before a counterpart is assigned.
     pub fn as_new_order(&self) -> SmallOrder {
         SmallOrder::new(
             Some(self.id),
@@ -213,7 +304,10 @@ impl Order {
             Some(self.expires_at),
         )
     }
-    /// Get the kind of the order
+    /// Parse the order kind from the string-encoded field.
+    ///
+    /// Returns [`ServiceError::InvalidOrderKind`] when `self.kind` does not
+    /// match a known [`Kind`] variant.
     pub fn get_order_kind(&self) -> Result<Kind, ServiceError> {
         if let Ok(kind) = Kind::from_str(&self.kind) {
             Ok(kind)
@@ -222,7 +316,10 @@ impl Order {
         }
     }
 
-    /// Get the status of the order in case
+    /// Parse the order status from the string-encoded field.
+    ///
+    /// Returns [`ServiceError::InvalidOrderStatus`] when `self.status` does
+    /// not match a known [`Status`] variant.
     pub fn get_order_status(&self) -> Result<Status, ServiceError> {
         if let Ok(status) = Status::from_str(&self.status) {
             Ok(status)
@@ -231,7 +328,10 @@ impl Order {
         }
     }
 
-    /// Compare the status of the order
+    /// Check that the order is currently in a specific [`Status`].
+    ///
+    /// Returns `Ok(())` on match and [`CantDoReason::InvalidOrderStatus`]
+    /// either on mismatch or when the stored status cannot be parsed.
     pub fn check_status(&self, status: Status) -> Result<(), CantDoReason> {
         match Status::from_str(&self.status) {
             Ok(s) => match s == status {
@@ -242,14 +342,14 @@ impl Order {
         }
     }
 
-    /// Check if the order is a buy order
+    /// Assert that the order is a [`Kind::Buy`] order.
     pub fn is_buy_order(&self) -> Result<(), CantDoReason> {
         if self.kind != Kind::Buy.to_string() {
             return Err(CantDoReason::InvalidOrderKind);
         }
         Ok(())
     }
-    /// Check if the order is a sell order
+    /// Assert that the order is a [`Kind::Sell`] order.
     pub fn is_sell_order(&self) -> Result<(), CantDoReason> {
         if self.kind != Kind::Sell.to_string() {
             return Err(CantDoReason::InvalidOrderKind);
@@ -257,7 +357,9 @@ impl Order {
         Ok(())
     }
 
-    /// Check if the sender is the creator of the order
+    /// Assert that `sender` is the maker (creator) of the order.
+    ///
+    /// Returns [`CantDoReason::InvalidPubkey`] when the pubkeys differ.
     pub fn sent_from_maker(&self, sender: PublicKey) -> Result<(), CantDoReason> {
         let sender = sender.to_string();
         if self.creator_pubkey != sender {
@@ -266,7 +368,10 @@ impl Order {
         Ok(())
     }
 
-    /// Check if the sender is the creator of the order
+    /// Assert that `sender` is **not** the maker of the order.
+    ///
+    /// Returns [`CantDoReason::InvalidPubkey`] when `sender` matches
+    /// `self.creator_pubkey`.
     pub fn not_sent_from_maker(&self, sender: PublicKey) -> Result<(), CantDoReason> {
         let sender = sender.to_string();
         if self.creator_pubkey == sender {
@@ -275,7 +380,7 @@ impl Order {
         Ok(())
     }
 
-    /// Get the creator pubkey
+    /// Parse the maker's public key as a Nostr [`PublicKey`].
     pub fn get_creator_pubkey(&self) -> Result<PublicKey, ServiceError> {
         match PublicKey::from_str(self.creator_pubkey.as_ref()) {
             Ok(pk) => Ok(pk),
@@ -283,7 +388,10 @@ impl Order {
         }
     }
 
-    /// Get the buyer pubkey
+    /// Parse the buyer trade public key.
+    ///
+    /// Returns [`ServiceError::InvalidPubkey`] when the field is absent or
+    /// cannot be parsed.
     pub fn get_buyer_pubkey(&self) -> Result<PublicKey, ServiceError> {
         if let Some(pk) = self.buyer_pubkey.as_ref() {
             PublicKey::from_str(pk).map_err(|_| ServiceError::InvalidPubkey)
@@ -291,7 +399,10 @@ impl Order {
             Err(ServiceError::InvalidPubkey)
         }
     }
-    /// Get the seller pubkey
+    /// Parse the seller trade public key.
+    ///
+    /// Returns [`ServiceError::InvalidPubkey`] when the field is absent or
+    /// cannot be parsed.
     pub fn get_seller_pubkey(&self) -> Result<PublicKey, ServiceError> {
         if let Some(pk) = self.seller_pubkey.as_ref() {
             PublicKey::from_str(pk).map_err(|_| ServiceError::InvalidPubkey)
@@ -299,7 +410,7 @@ impl Order {
             Err(ServiceError::InvalidPubkey)
         }
     }
-    /// Get the master buyer pubkey
+    /// Parse the buyer master identity public key.
     pub fn get_master_buyer_pubkey(&self) -> Result<PublicKey, ServiceError> {
         if let Some(pk) = self.master_buyer_pubkey.as_ref() {
             PublicKey::from_str(pk).map_err(|_| ServiceError::InvalidPubkey)
@@ -307,7 +418,7 @@ impl Order {
             Err(ServiceError::InvalidPubkey)
         }
     }
-    /// Get the master seller pubkey
+    /// Parse the seller master identity public key.
     pub fn get_master_seller_pubkey(&self) -> Result<PublicKey, ServiceError> {
         if let Some(pk) = self.master_seller_pubkey.as_ref() {
             PublicKey::from_str(pk).map_err(|_| ServiceError::InvalidPubkey)
@@ -316,11 +427,17 @@ impl Order {
         }
     }
 
-    /// Check if the order is a range order
+    /// `true` when both `min_amount` and `max_amount` are set, i.e. this is
+    /// a range order.
     pub fn is_range_order(&self) -> bool {
         self.min_amount.is_some() && self.max_amount.is_some()
     }
 
+    /// Increment the payment-failure counter.
+    ///
+    /// On the first failure, sets [`Self::failed_payment`] to `true` and
+    /// [`Self::payment_attempts`] to `1`. On subsequent failures the counter
+    /// is bumped, capped at `retries_number`.
     pub fn count_failed_payment(&mut self, retries_number: i64) {
         if !self.failed_payment {
             self.failed_payment = true;
@@ -330,19 +447,25 @@ impl Order {
         }
     }
 
-    /// Check if the order has no amount
+    /// `true` when `amount == 0`, meaning the sats amount is not fixed and
+    /// will be computed from the fiat amount and market price.
     pub fn has_no_amount(&self) -> bool {
         self.amount == 0
     }
 
-    /// Set the timestamp to now
+    /// Set [`Self::taken_at`] to the current Unix timestamp.
     pub fn set_timestamp_now(&mut self) {
         self.taken_at = Timestamp::now().as_secs() as i64
     }
 
-    /// Check if a user is creating a full privacy order so he doesn't to have reputation
-    /// compare master keys with the order keys if they are the same the user is in full privacy mode
-    /// otherwise the user is not in normal mode and has a reputation
+    /// Compare the trade pubkeys against the master pubkeys to detect which
+    /// sides of the trade are operating in full privacy mode.
+    ///
+    /// Returns a `(buyer_normal_idkey, seller_normal_idkey)` tuple. Each
+    /// value is `Some(master_pubkey)` when that side is running in normal
+    /// mode (trade key differs from master key, so the user is willing to
+    /// associate the trade with its reputation); `None` when the side is in
+    /// full privacy mode.
     pub fn is_full_privacy_order(&self) -> Result<(Option<String>, Option<String>), ServiceError> {
         let (mut normal_buyer_idkey, mut normal_seller_idkey) = (None, None);
 
@@ -362,10 +485,13 @@ impl Order {
 
         Ok((normal_buyer_idkey, normal_seller_idkey))
     }
-    /// Setup the dispute status
+    /// Mark the order as in dispute and record which side initiated it.
     ///
-    /// If the pubkey is the buyer, set the buyer dispute to true
-    /// If the pubkey is the seller, set the seller dispute to true
+    /// When `is_buyer_dispute` is `true` the buyer flag is set, otherwise
+    /// the seller flag. The order status is then transitioned to
+    /// [`Status::Dispute`]. Returns
+    /// [`CantDoReason::DisputeCreationError`] when the appropriate flag was
+    /// already set (avoids registering the same dispute twice).
     pub fn setup_dispute(&mut self, is_buyer_dispute: bool) -> Result<(), CantDoReason> {
         // Get the opposite dispute status
         let is_seller_dispute = !is_buyer_dispute;
@@ -394,33 +520,57 @@ impl Order {
     }
 }
 
-/// We use this struct to create a new order
+/// Compact, wire-friendly view of an order.
+///
+/// `SmallOrder` carries the fields needed to publish a new order or to show
+/// a listing entry to a client, without the bookkeeping fields kept in
+/// [`Order`] (hold invoice hash, fees, dispute flags, etc.). It is the shape
+/// used by [`Payload::Order`] and siblings.
+///
+/// Unknown fields are rejected at deserialization time (`deny_unknown_fields`).
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct SmallOrder {
+    /// Order id. `None` for orders that have not been persisted yet.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<Uuid>,
+    /// Order kind.
     pub kind: Option<Kind>,
+    /// Current status.
     pub status: Option<Status>,
+    /// Sats amount. `0` when the sats amount is derived from the fiat
+    /// amount and live market price.
     pub amount: i64,
+    /// Fiat currency code (e.g. "EUR").
     pub fiat_code: String,
+    /// Lower bound of a range order (fiat amount).
     pub min_amount: Option<i64>,
+    /// Upper bound of a range order (fiat amount).
     pub max_amount: Option<i64>,
+    /// Fiat amount of the trade.
     pub fiat_amount: i64,
+    /// Free-form payment method description.
     pub payment_method: String,
+    /// Premium percentage applied on top of the spot price.
     pub premium: i64,
+    /// Buyer trade public key, when known.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub buyer_trade_pubkey: Option<String>,
+    /// Seller trade public key, when known.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub seller_trade_pubkey: Option<String>,
+    /// Buyer's Lightning payout invoice, when already provided.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub buyer_invoice: Option<String>,
+    /// Unix timestamp (seconds) when the order was created.
     pub created_at: Option<i64>,
+    /// Unix timestamp (seconds) when the order expires automatically.
     pub expires_at: Option<i64>,
 }
 
 #[allow(dead_code)]
 impl SmallOrder {
+    /// Construct a new [`SmallOrder`] from all of its fields.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: Option<Uuid>,
@@ -457,17 +607,18 @@ impl SmallOrder {
             expires_at,
         }
     }
-    /// New order from json string
+    /// Parse a [`SmallOrder`] from its JSON representation.
     pub fn from_json(json: &str) -> Result<Self, ServiceError> {
         serde_json::from_str(json).map_err(|_| ServiceError::MessageSerializationError)
     }
 
-    /// Get order as json string
+    /// Serialize the order to a JSON string.
     pub fn as_json(&self) -> Result<String, ServiceError> {
         serde_json::to_string(&self).map_err(|_| ServiceError::MessageSerializationError)
     }
 
-    /// Get the amount of sats or the string "Market price"
+    /// Return the sats amount as a string, or the literal `"Market price"`
+    /// when the amount is `0` (to be computed at take-time).
     pub fn sats_amount(&self) -> String {
         if self.amount == 0 {
             "Market price".to_string()
@@ -475,7 +626,9 @@ impl SmallOrder {
             self.amount.to_string()
         }
     }
-    /// Check if fiat_amount is positive
+    /// Assert that the fiat amount is strictly positive.
+    ///
+    /// Returns [`CantDoReason::InvalidAmount`] otherwise.
     pub fn check_fiat_amount(&self) -> Result<(), CantDoReason> {
         if self.fiat_amount <= 0 {
             return Err(CantDoReason::InvalidAmount);
@@ -483,7 +636,12 @@ impl SmallOrder {
         Ok(())
     }
 
-    /// Check if amount (sats) is non-negative when explicitly set
+    /// Assert that the sats amount is non-negative.
+    ///
+    /// A value of `0` is explicitly accepted because it signals that the
+    /// sats amount will be derived from the fiat amount and the market
+    /// price at take-time. Returns [`CantDoReason::InvalidAmount`] when the
+    /// amount is negative.
     pub fn check_amount(&self) -> Result<(), CantDoReason> {
         if self.amount < 0 {
             return Err(CantDoReason::InvalidAmount);
@@ -491,7 +649,11 @@ impl SmallOrder {
         Ok(())
     }
 
-    /// Check if the order has a zero amount and a premium or fiat amount
+    /// Reject orders that set both `amount` and `premium` at the same time.
+    ///
+    /// A premium only makes sense when the sats amount is market-priced;
+    /// combining a fixed sats amount with a premium is ambiguous and
+    /// returns [`CantDoReason::InvalidParameters`].
     pub fn check_zero_amount_with_premium(&self) -> Result<(), CantDoReason> {
         let premium = (self.premium != 0).then_some(self.premium);
         let sats_amount = (self.amount != 0).then_some(self.amount);
@@ -502,7 +664,13 @@ impl SmallOrder {
         Ok(())
     }
 
-    /// Check if the order is a range order and if the amount is zero
+    /// Validate the bounds of a range order and push them into `amounts`.
+    ///
+    /// When both `min_amount` and `max_amount` are set, they must be
+    /// non-negative, `min < max`, and `amount` must be `0` (range orders
+    /// cannot fix the sats amount). On success, `amounts` is cleared and
+    /// replaced with `[min, max]`. On failure returns
+    /// [`CantDoReason::InvalidAmount`].
     pub fn check_range_order_limits(&self, amounts: &mut Vec<i64>) -> Result<(), CantDoReason> {
         // Check if the min and max amount are valid and update the vector
         if let (Some(min), Some(max)) = (self.min_amount, self.max_amount) {
@@ -522,7 +690,12 @@ impl SmallOrder {
         Ok(())
     }
 
-    /// Check if the fiat currency is accepted
+    /// Verify that the order's fiat code appears in the list of accepted
+    /// currencies.
+    ///
+    /// An empty allowlist disables the check (every currency is accepted).
+    /// Returns [`CantDoReason::InvalidFiatCurrency`] when the currency is
+    /// not allowed.
     pub fn check_fiat_currency(
         &self,
         fiat_currencies_accepted: &[String],

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,7 +1,14 @@
-// This module re-exports commonly used types and traits for convenience.
-// It allows users to import everything they need from a single module
-//
-//! Prelude
+//! Convenience re-exports and shared constants.
+//!
+//! This module gathers the types you are most likely to need when building a
+//! Mostro client or daemon so they can be imported in bulk:
+//!
+//! ```
+//! use mostro_core::prelude::*;
+//! ```
+//!
+//! It also defines the Nostr event kinds used by the protocol and the minimum
+//! and maximum rating bounds.
 
 pub use crate::dispute::{Dispute, SolverDisputeInfo, Status as DisputeStatus};
 pub use crate::error::{CantDoReason, MostroError, ServiceError};
@@ -18,14 +25,20 @@ pub use crate::user::{User, UserInfo};
 pub(crate) use serde::{Deserialize, Serialize};
 pub use MostroError::*;
 
-/// CONSTANTS exported for convenience
-// Max rating for a user
+/// Maximum rating value a user can receive.
 pub const MAX_RATING: u8 = 5;
-// Min rating for a user
+/// Minimum rating value a user can receive.
 pub const MIN_RATING: u8 = 1;
-// Addressable event kind must be between 30000 and 39999 (NIP-1)
+/// Nostr event kind used by Mostro to publish orders.
+///
+/// Addressable event kinds are in the `30000..=39999` range (NIP-01).
 pub const NOSTR_ORDER_EVENT_KIND: u16 = 38383;
+/// Nostr event kind used to publish user ratings.
 pub const NOSTR_RATING_EVENT_KIND: u16 = 38384;
+/// Nostr event kind used to publish node information events.
 pub const NOSTR_INFO_EVENT_KIND: u16 = 38385;
+/// Nostr event kind used to publish disputes.
 pub const NOSTR_DISPUTE_EVENT_KIND: u16 = 38386;
+/// Current Mostro protocol version. Embedded in every outgoing
+/// [`MessageKind`](crate::message::MessageKind).
 pub(crate) const PROTOCOL_VER: u8 = 1;

--- a/src/rating.rs
+++ b/src/rating.rs
@@ -1,19 +1,36 @@
+//! Encoding of user reputation as Nostr event tags.
+//!
+//! Mostro publishes user reputation as addressable Nostr events of kind
+//! [`NOSTR_RATING_EVENT_KIND`](crate::prelude::NOSTR_RATING_EVENT_KIND). The
+//! [`Rating`] struct in this module mirrors the tag set used on those events
+//! and provides helpers to serialize to / deserialize from both JSON and
+//! `nostr_sdk::Tags`.
+
 use nostr_sdk::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::error::ServiceError;
 
-/// We use this struct to create a user reputation
+/// User reputation snapshot, suitable for publishing as Nostr tags.
+///
+/// The fields are the same aggregates stored on [`crate::user::User`], but
+/// typed for transport (unsigned integers for counts, `u8` for rating values).
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Rating {
+    /// Total number of ratings received.
     pub total_reviews: u64,
+    /// Weighted rating average across all reviews.
     pub total_rating: f64,
+    /// Most recent rating, in the `MIN_RATING..=MAX_RATING` range.
     pub last_rating: u8,
+    /// Highest rating ever received.
     pub max_rate: u8,
+    /// Lowest rating ever received.
     pub min_rate: u8,
 }
 
 impl Rating {
+    /// Construct a new [`Rating`] from its individual components.
     pub fn new(
         total_reviews: u64,
         total_rating: f64,
@@ -30,17 +47,23 @@ impl Rating {
         }
     }
 
-    /// New order from json string
+    /// Parse a [`Rating`] from its JSON representation.
+    ///
+    /// Returns [`ServiceError::MessageSerializationError`] if `json` is not a
+    /// valid serialization of this type.
     pub fn from_json(json: &str) -> Result<Self, ServiceError> {
         serde_json::from_str(json).map_err(|_| ServiceError::MessageSerializationError)
     }
 
-    /// Get order as json string
+    /// Serialize the rating to a JSON string.
     pub fn as_json(&self) -> Result<String, ServiceError> {
         serde_json::to_string(&self).map_err(|_| ServiceError::MessageSerializationError)
     }
 
-    /// Transform Rating struct to tuple vector to easily interact with Nostr
+    /// Encode the rating as a set of Nostr tags, ready to attach to an event.
+    ///
+    /// The returned [`Tags`] value contains one entry per numeric field plus
+    /// a `z` marker tag identifying the payload as a rating.
     pub fn to_tags(&self) -> Result<Tags> {
         let tags = vec![
             Tag::custom(
@@ -74,7 +97,12 @@ impl Rating {
         Ok(tags)
     }
 
-    /// Transform tuple vector to Rating struct
+    /// Rebuild a [`Rating`] from a set of Nostr tags previously produced by
+    /// [`Rating::to_tags`].
+    ///
+    /// Unknown tag keys are ignored so that the function keeps working if the
+    /// server adds new metadata fields. Returns a [`ServiceError`] if a
+    /// required key carries a non-parseable value.
     pub fn from_tags(tags: Tags) -> Result<Self, ServiceError> {
         let mut total_reviews = 0;
         let mut total_rating = 0.0;

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,41 +1,78 @@
+//! Persistent user representation and reputation helpers.
+//!
+//! The [`User`] struct is the database-backed record Mostro keeps for every
+//! identity that has interacted with the system. It tracks rating aggregates,
+//! administrative flags and the last trade index used by the user, which is
+//! required so that new orders always carry a strictly increasing trade index.
+//!
+//! [`UserInfo`] is a lightweight view of the same data that can safely be
+//! shared with a counterpart during a trade without leaking internals.
+
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "sqlx")]
 use sqlx::FromRow;
 
+/// Public snapshot of a user's reputation shared with peers during a trade.
+///
+/// Unlike [`User`], `UserInfo` contains only the values a counterpart needs
+/// to decide whether to trade: aggregated rating, number of reviews and how
+/// many days the user has been operating on Mostro.
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 
 pub struct UserInfo {
-    /// User's rating
+    /// Aggregated rating value for the user (see [`crate::rating::Rating`]).
     pub rating: f64,
-    /// User's total reviews
+    /// Total number of ratings received.
     pub reviews: i64,
-    /// User's operating days
+    /// Number of days since the user account was created.
     pub operating_days: u64,
 }
 
-/// Database representation of an user
+/// Database representation of a Mostro user.
+///
+/// This is the canonical row stored on the Mostro node. It tracks identity
+/// data (`pubkey`), administrative role flags, the last trade index used by
+/// the user and rating aggregates used to compute reputation.
 #[cfg_attr(feature = "sqlx", derive(FromRow))]
 #[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
 pub struct User {
+    /// Master public key of the user, hex encoded.
     pub pubkey: String,
+    /// `1` when the user has admin privileges, `0` otherwise. Stored as
+    /// `i64` to match the underlying SQLite representation.
     pub is_admin: i64,
+    /// Optional password used to authenticate privileged admin actions.
     pub admin_password: Option<String>,
+    /// `1` when the user is a dispute solver, `0` otherwise.
     pub is_solver: i64,
+    /// `1` when the user is banned from the platform, `0` otherwise.
     pub is_banned: i64,
+    /// Free-form category bucket. Reserved for future segmentation.
     pub category: i64,
-    /// We have to be sure that when a user creates a new order (or takes an order),
-    /// the trade_index is greater than the one we have in database
+    /// Last trade index used by this user. When a user creates a new order
+    /// (or takes one) the incoming trade index must be strictly greater than
+    /// this value, or the request is rejected.
     pub last_trade_index: i64,
+    /// Total number of ratings the user has received.
     pub total_reviews: i64,
+    /// Weighted rating average computed from all received ratings.
     pub total_rating: f64,
+    /// Most recent rating received, in the `MIN_RATING..=MAX_RATING` range.
     pub last_rating: i64,
+    /// Highest rating ever received.
     pub max_rating: i64,
+    /// Lowest rating ever received.
     pub min_rating: i64,
+    /// Unix timestamp (seconds) when the user record was created.
     pub created_at: i64,
 }
 
 impl User {
+    /// Create a new [`User`] with fresh rating aggregates.
+    ///
+    /// `trade_index` becomes the user's `last_trade_index`. The `created_at`
+    /// timestamp is set to the current system time.
     pub fn new(
         pubkey: String,
         is_admin: i64,
@@ -61,7 +98,23 @@ impl User {
         }
     }
 
-    /// Update user rating
+    /// Record a new rating for the user and refresh the aggregates.
+    ///
+    /// The first vote is weighted by `1/2` so that a single review cannot
+    /// anchor a perfect or disastrous reputation. Subsequent votes update
+    /// `total_rating` with an incremental running-average formula.
+    /// `min_rating` and `max_rating` are tightened as new extremes arrive.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use mostro_core::user::User;
+    ///
+    /// let mut user = User::new("pubkey".into(), 0, 0, 0, 0, 0);
+    /// user.update_rating(5);
+    /// assert_eq!(user.total_reviews, 1);
+    /// assert_eq!(user.max_rating, 5);
+    /// ```
     pub fn update_rating(&mut self, rating: u8) {
         // Update user reputation
         // increment first


### PR DESCRIPTION
Raise rustdoc coverage to 100% for public items. Add crate-level overview, per-module docs, per-variant docs for all public enums, per-field docs for all public structs, and per-method docs across the API surface. Enable `#![warn(missing_docs)]` to prevent regressions.