### PR TITLE
fix(nip59): split identity and trade keys in wrap/unwrap

### DIFF
--- a/docs/NIP59_TRANSPORT.md
+++ b/docs/NIP59_TRANSPORT.md
@@ -8,8 +8,9 @@ unwraps Mostro messages for transport over Nostr using NIP-59
 
 - Centralize the wrap / unwrap pipeline so clients do not reimplement
   NIP-59 glue.
-- Cryptographically bind every message to the sender's trade identity
-  via an inner tuple signature.
+- Honor the Mostro key-management split: long-lived **identity key**
+  signs the seal; per-order **trade key** authors the rumor and
+  produces the inner tuple signature.
 - Preserve NIP-59 metadata hygiene: CSPRNG-based timestamp jitter,
   ephemeral outer signer, optional expiration, optional PoW.
 - Keep a strict error contract that distinguishes "not addressed to
@@ -21,6 +22,26 @@ The module deliberately does **not** manage relays, subscriptions,
 waiters, deduplication, persistence or retries. It returns an `Event`
 ready to publish and a decoder for incoming events — the caller owns
 transport policy.
+
+## Key split
+
+Mostro derives keys per
+[NIP-06](https://github.com/nostr-protocol/nips/blob/master/06.md) at
+`m/44'/1237'/38383'/0/i`:
+
+- `i = 0` → **identity key**. Stable per user; signs the seal (kind
+  13) and drives the NIP-44 encryption of the seal content so the
+  receiver can decrypt via `(receiver_secret, seal.pubkey)`. Sending
+  the identity key to a Mostro node is what lets the node attach
+  reputation to orders.
+- `i ≥ 1` → **trade key**. Rotated per order; authors the rumor
+  (kind 1) and produces the Schnorr signature carried in the inner
+  tuple.
+
+**Full-privacy mode** — a client that does not want reputation simply
+reuses its trade key as the identity (pass the same `Keys` as both
+`identity_keys` and `trade_keys`). `seal.pubkey` then coincides with
+`rumor.pubkey` and no stable identity leaks to the node.
 
 ## Message pipeline
 
@@ -37,7 +58,8 @@ JSON( (Message, Option<Signature>) )          ← inner tuple
 Rumor (UnsignedEvent, kind 1, author = trade_keys)
   │
   ▼
-Seal  (kind 13, signed by trade_keys, content = NIP-44(rumor))
+Seal  (kind 13, signed by identity_keys,
+       content = NIP-44(rumor) under identity_keys ↔ receiver)
   │
   ▼
 GiftWrap (kind 1059, signed by fresh ephemeral keys,
@@ -46,10 +68,11 @@ GiftWrap (kind 1059, signed by fresh ephemeral keys,
           optional PoW, randomized created_at)
 ```
 
-`nostr-sdk` 0.44 enforces that the rumor author equals the seal signer
-(`nip59::Error::SenderMismatch`). Both layers are therefore signed with
-`trade_keys`; the outer GiftWrap is always signed with a freshly
-generated ephemeral keypair.
+`nostr-sdk` 0.44's `nip59::extract_rumor` enforces
+`seal.pubkey == rumor.pubkey` and rejects the split above with
+`SenderMismatch`. `unwrap_message` therefore performs its own NIP-44
+decryption and seal-signature verification instead of calling
+`extract_rumor`.
 
 ## Public API
 
@@ -74,20 +97,23 @@ identity binding.
 pub struct UnwrappedMessage {
     pub message: Message,              // decoded Mostro payload
     pub signature: Option<Signature>,  // Some iff sender set signed = true
-    pub sender: PublicKey,             // rumor / seal author
+    pub sender: PublicKey,             // rumor author (trade key)
+    pub identity: PublicKey,           // seal signer (identity key)
     pub created_at: Timestamp,         // rumor created_at (not the wrap's)
 }
 ```
 
-`sender` is the trade pubkey of the sender. Because `nostr-sdk`
-rejects `SenderMismatch`, `sender` is also the pubkey that signed the
-seal, which is the same key that produced the inner tuple signature.
+`sender` is the rumor author — the per-order trade pubkey, also the
+pubkey that produced the inner tuple signature. `identity` is the
+seal signer, i.e. the long-lived pubkey the sender uses to accrue
+reputation. In full-privacy mode `identity == sender`.
 
 ### `wrap_message`
 
 ```rust
 pub async fn wrap_message(
     message: &Message,
+    identity_keys: &Keys,
     trade_keys: &Keys,
     receiver: PublicKey,
     opts: WrapOptions,
@@ -102,8 +128,11 @@ Builds a publishable GiftWrap event. Steps:
 3. Build the rumor as `EventBuilder::text_note(inner_json)` authored
    by `trade_keys.public_key()`. **No PoW is mined on the rumor** —
    it is encrypted inside the seal and never published alone.
-4. Seal via `EventBuilder::seal(trade_keys, &receiver, rumor)` and
-   sign with `trade_keys`.
+4. Seal via `EventBuilder::seal(identity_keys, &receiver, rumor)`
+   (NIP-44 encrypts the rumor JSON under `identity_keys ↔ receiver`)
+   and sign the resulting event with `identity_keys`. Encryption and
+   signing must use the same key so the receiver can derive the
+   shared secret from `seal.pubkey` alone.
 5. Encrypt the seal JSON with NIP-44 under a fresh ephemeral key for
    `receiver`, attach `["p", receiver]` (mandatory) and optionally
    `["expiration", ts]`, stamp `created_at =
@@ -111,30 +140,51 @@ Builds a publishable GiftWrap event. Steps:
    0..172_800 s in the past), mine PoW at `opts.pow`, sign with the
    ephemeral key.
 
+For full-privacy mode, pass the same `Keys` as both `identity_keys`
+and `trade_keys`.
+
 ### `unwrap_message`
 
 ```rust
 pub async fn unwrap_message(
     event: &Event,
-    trade_keys: &Keys,
+    receiver_keys: &Keys,
 ) -> Result<Option<UnwrappedMessage>, MostroError>
 ```
+
+Implementation bypasses `nip59::extract_rumor` to accommodate the
+identity/trade key split. Steps:
+
+1. Reject events whose kind is not `GiftWrap`.
+2. `nip44::decrypt(receiver_secret, event.pubkey, event.content)` —
+   failure here is the "not addressed to me" signal and returns
+   `Ok(None)`.
+3. Parse the decrypted payload as an `Event`, reject if its kind is
+   not `Seal`, verify its Schnorr signature.
+4. `nip44::decrypt(receiver_secret, seal.pubkey, seal.content)` to
+   recover the rumor JSON. `seal.pubkey` is the identity key used on
+   both sides of the outer seal encryption.
+5. Parse the decrypted payload as an `UnsignedEvent`, reject if its
+   kind is not `TextNote`.
+6. `serde_json::from_str` the rumor content into
+   `(Message, Option<String>)`.
+7. When a signature string is present, parse it, verify it against
+   `rumor.pubkey` (the trade key), and populate
+   `UnwrappedMessage.signature`.
 
 Contract:
 
 - `Ok(Some(_))` on successful unwrap **and** (when `signed`)
   successful signature verification.
 - `Ok(None)` **only** when the outer NIP-44 layer cannot be decrypted
-  with `trade_keys`. This is the canonical "not addressed to me"
-  signal — callers can iterate across multiple candidate trade keys
-  and treat `None` as "try the next one".
+  with `receiver_keys`. This is the canonical "not addressed to me"
+  signal — callers can iterate across multiple candidate receiver
+  keys and treat `None` as "try the next one".
 - `Err(MostroInternalErr(_))` for every other failure: wrong event
-  kind, corrupted seal JSON, invalid seal signature, NIP-59
-  `SenderMismatch`, malformed inner tuple JSON, malformed signature
-  hex, signature that does not verify against `sender`.
-
-The `Signer` / non-`Signer` split on `nip59::Error` is used to
-implement this contract (see "Error routing" below).
+  kind, corrupted seal JSON, wrong seal kind, invalid seal signature,
+  inner NIP-44 decrypt failure, malformed rumor JSON, wrong rumor
+  kind, malformed inner tuple JSON, malformed signature hex,
+  signature that does not verify against `sender`.
 
 ### `validate_response`
 
@@ -165,15 +215,21 @@ Mismatched or unexpectedly-missing request ids surface as
 
 ## Error routing
 
-`nip59::extract_rumor` (from `nostr-sdk`) returns four error variants.
-`unwrap_message` routes them as follows:
+The unwrap path routes its own failures without dispatching on
+`nip59::Error`:
 
-| Upstream variant          | Cause                                   | Result               |
-|---------------------------|-----------------------------------------|----------------------|
-| `Signer(_)`               | outer NIP-44 decrypt failed             | `Ok(None)`           |
-| `Event(_)`                | bad seal JSON / signature / rumor JSON  | `Err(NostrError)`    |
-| `SenderMismatch`          | rumor author ≠ seal author              | `Err(NostrError)`    |
-| `NotGiftWrap`             | wrong kind (pre-checked, defensive)     | `Err(NostrError)`    |
+| Stage                                | Cause                                       | Result               |
+|--------------------------------------|---------------------------------------------|----------------------|
+| outer `nip44::decrypt`               | payload not addressed to `receiver_keys`    | `Ok(None)`           |
+| `Event::from_json` on seal           | corrupted seal payload                      | `Err(NostrError)`    |
+| `seal.kind != Kind::Seal`            | decryptable but wrong kind                  | `Err(UnexpectedErr)` |
+| `seal.verify_signature()`            | seal signature invalid                      | `Err(NostrError)`    |
+| inner `nip44::decrypt` on seal       | seal content unreadable with `seal.pubkey`  | `Err(DecryptionErr)` |
+| `UnsignedEvent::from_json` on rumor  | corrupted rumor payload                     | `Err(NostrError)`    |
+| `rumor.kind != Kind::TextNote`       | wrong rumor kind                            | `Err(UnexpectedErr)` |
+| `serde_json::from_str` on tuple      | malformed `(Message, Option<String>)` JSON  | `Err(MessageSerErr)` |
+| `Signature::from_str` on tuple sig   | malformed hex signature                     | `Err(UnexpectedErr)` |
+| `Message::verify_signature`          | signature does not verify vs `rumor.pubkey` | `Err(UnexpectedErr)` |
 
 The `p` tag is **not** used as an addressing filter. NIP-44 decrypt
 success is a cryptographic proof of addressing; a `p` tag is a
@@ -187,16 +243,18 @@ affecting decrypt-ability.
 When `signed = true`, the inner tuple carries a Schnorr signature
 over the exact JSON bytes of `message`, produced with `trade_keys`.
 `unwrap_message` parses the signature strictly and verifies it
-against `unwrapped.sender` (the trade pubkey that signed the seal).
+against `rumor.pubkey` (the trade pubkey exposed as
+`UnwrappedMessage.sender`).
 
-The verification is redundant with the seal signature in the
-honest-client case — `nostr-sdk` already rejects seals whose author
-does not match the rumor — but it defends against any future drift
-where the two layers diverge, and it gives callers a single
-`UnwrappedMessage.signature` they can re-verify or forward on its
-own. Malformed signatures and non-verifying signatures both surface
-as errors: "the sender did not sign" and "the sender claims a
-signature we cannot trust" must never look the same to the caller.
+The seal layer separately binds the exchange to the sender's
+long-lived identity (`UnwrappedMessage.identity`). In the honest
+client these two pubkeys relate via the NIP-06 derivation tree, but
+the transport treats them as independent: a mismatched pair does not
+violate the transport contract, it simply means the tuple signature
+and seal signature were produced by different keys. Malformed
+signatures and non-verifying signatures both surface as errors: "the
+sender did not sign" and "the sender claims a signature we cannot
+trust" must never look the same to the caller.
 
 ### Timestamp blur
 
@@ -232,7 +290,8 @@ use mostro_core::prelude::*;
 
 let wrapped = wrap_message(
     &message,                // Message with an explicit request_id
-    &trade_keys,             // per-trade keys
+    &identity_keys,          // long-lived identity keys (index 0)
+    &trade_keys,             // per-order trade keys (index ≥ 1)
     mostro_pubkey,           // PublicKey of the Mostro node
     WrapOptions::default(),  // signed = true, pow = 0, no expiration
 )
@@ -241,13 +300,23 @@ let wrapped = wrap_message(
 // Caller publishes `wrapped` to its relay pool.
 ```
 
-### Handling incoming events across multiple candidate trade keys
+For full-privacy mode (no reputation), pass the trade keys as both
+arguments:
+
+```rust
+let wrapped = wrap_message(
+    &message, &trade_keys, &trade_keys,
+    mostro_pubkey, WrapOptions::default(),
+).await?;
+```
+
+### Handling incoming events across multiple candidate receiver keys
 
 ```rust
 async fn try_unwrap(event: &Event, candidates: &[Keys]) -> Option<UnwrappedMessage> {
     for keys in candidates {
         match unwrap_message(event, keys).await {
-            Ok(Some(msg)) => return Some(msg),   // addressed to this trade key
+            Ok(Some(msg)) => return Some(msg),   // addressed to this key
             Ok(None) => continue,                // not this key, try the next
             Err(_e) => {
                 // genuine protocol error — log, drop, or escalate
@@ -265,16 +334,18 @@ surfacing in logs or metrics.
 ### Validating a response
 
 ```rust
-let unwrapped = unwrap_message(&event, &trade_keys).await?
+let unwrapped = unwrap_message(&event, &receiver_keys).await?
     .ok_or_else(/* not addressed to us */)?;
 
 validate_response(&unwrapped.message, Some(request_id))?;
 
-// Re-verify the signature if the caller wants to forward it:
+// Re-verify the tuple signature (binds message to trade key):
 if let Some(sig) = unwrapped.signature {
     let json = unwrapped.message.as_json()?;
     assert!(Message::verify_signature(json, unwrapped.sender, sig));
 }
+
+// unwrapped.identity is the sender's stable reputation key.
 ```
 
 ## Dependency surface
@@ -289,12 +360,16 @@ if let Some(sig) = unwrapped.signature {
 `src/nip59.rs` carries the behavioral tests that lock in the
 contract:
 
-- `wrap_then_unwrap_roundtrip`
+- `wrap_then_unwrap_roundtrip` — dual-key round trip; asserts
+  `sender == trade_keys.public_key()` and
+  `identity == identity_keys.public_key()`.
+- `full_privacy_mode_identity_equals_sender` — same `Keys` passed for
+  both identity and trade; `identity == sender`.
 - `signature_is_verifiable_with_trade_pubkey`
 - `unsigned_wrap_has_no_signature`
 - `expiration_tag_is_set_when_provided`
-- `unwrap_with_wrong_trade_keys_returns_none` — outer decrypt failure
-  path.
+- `unwrap_with_wrong_receiver_keys_returns_none` — outer decrypt
+  failure path.
 - `unwrap_with_corrupted_seal_returns_err` — decryptable but
   semantically invalid seal payload.
 - `unwrap_with_malformed_signature_errors` — `Some("not-a-hex-sig")`

--- a/src/nip59.rs
+++ b/src/nip59.rs
@@ -7,10 +7,18 @@
 //! Message -> JSON((Message, Option<Signature>)) -> Rumor -> Seal -> GiftWrap
 //! ```
 //!
-//! This module centralizes wrap/unwrap so clients do not need to reimplement
-//! NIP-59 glue themselves. It does not manage relays, subscriptions, waiters
-//! or persistence — the returned `Event` is ready to publish, and the caller
-//! decides how to do so.
+//! Mostro splits signing across two keys: a long-lived **identity key**
+//! signs the seal (and encrypts it to the receiver), while a per-trade
+//! **trade key** authors the rumor and produces the inner tuple signature.
+//! This deliberately breaks NIP-59's "rumor author == seal signer"
+//! convention that `nostr-sdk` 0.44 enforces via `SenderMismatch`, so the
+//! unwrap path does its own NIP-44 + signature verification instead of
+//! calling `nip59::extract_rumor`.
+//!
+//! The module centralizes wrap/unwrap so clients do not need to reimplement
+//! NIP-59 glue themselves. It does not manage relays, subscriptions,
+//! waiters or persistence — the returned `Event` is ready to publish, and
+//! the caller decides how to do so.
 
 use std::str::FromStr;
 
@@ -52,8 +60,12 @@ pub struct UnwrappedMessage {
     /// Signature of the JSON-serialized `Message`, produced with the sender's
     /// trade keys. Present only when the sender set `signed = true`.
     pub signature: Option<Signature>,
-    /// Rumor author (the sender's trade public key).
+    /// Rumor author — the sender's trade public key.
     pub sender: PublicKey,
+    /// Seal signer — the sender's long-lived identity public key. In
+    /// full-privacy mode (where the client reuses its trade key as identity)
+    /// this equals `sender`.
+    pub identity: PublicKey,
     /// Rumor `created_at` timestamp.
     pub created_at: Timestamp,
 }
@@ -61,17 +73,17 @@ pub struct UnwrappedMessage {
 /// Build a GiftWrap event (`kind: 1059`) ready to be published to a relay.
 ///
 /// * `message` — the Mostro message to send.
-/// * `trade_keys` — per-trade keys. Author of the rumor, signer of the Seal,
-///   and signer of the inner tuple signature when `opts.signed == true`.
+/// * `identity_keys` — long-lived identity keys. Sign the seal (kind 13)
+///   and encrypt it to `receiver` via NIP-44. Callers that want the
+///   "full privacy" mode (no stable identity, no reputation) should pass
+///   the same value as `trade_keys`.
+/// * `trade_keys` — per-trade keys. Author of the rumor (kind 1) and
+///   signer of the inner tuple signature when `opts.signed == true`.
 /// * `receiver` — the Mostro node public key.
 /// * `opts` — wrap options (PoW, expiration, signed).
-///
-/// `nostr-sdk` 0.44 enforces that the rumor author equals the seal signer
-/// (NIP-59 `SenderMismatch`), so both layers are signed with `trade_keys`.
-/// The inner tuple signature (produced with `trade_keys`) is what allows
-/// Mostro to cryptographically bind the message to the trade identity.
 pub async fn wrap_message(
     message: &Message,
+    identity_keys: &Keys,
     trade_keys: &Keys,
     receiver: PublicKey,
     opts: WrapOptions,
@@ -92,10 +104,14 @@ pub async fn wrap_message(
     // so mining its event id would burn CPU for nothing.
     let rumor = EventBuilder::text_note(content).build(trade_keys.public_key());
 
-    let seal: Event = EventBuilder::seal(trade_keys, &receiver, rumor)
+    // Seal is encrypted and signed with identity_keys so the receiver can
+    // decrypt it via (receiver_secret, seal.pubkey) — this keeps seal.pubkey
+    // consistent with the encryption key, while leaving rumor.pubkey free to
+    // carry the per-trade key (the mismatch standard NIP-59 rejects).
+    let seal: Event = EventBuilder::seal(identity_keys, &receiver, rumor)
         .await
         .map_err(|e| MostroError::MostroInternalErr(ServiceError::NostrError(e.to_string())))?
-        .sign(trade_keys)
+        .sign(identity_keys)
         .await
         .map_err(|e| MostroError::MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
 
@@ -140,17 +156,21 @@ fn gift_wrap_from_seal_with_pow(
         .map_err(|e| MostroError::MostroInternalErr(ServiceError::NostrError(e.to_string())))
 }
 
-/// Try to open an incoming GiftWrap with the given `trade_keys`.
+/// Try to open an incoming GiftWrap with the given `receiver_keys`.
 ///
 /// Returns `Ok(None)` only when the outer NIP-44 layer could not be
-/// decrypted with `trade_keys` — the canonical "not addressed to me"
-/// signal, so callers can try multiple trade keys without treating each
-/// miss as fatal. Every other failure (corrupted seal, malformed rumor
-/// JSON, seal/rumor pubkey mismatch, invalid signatures, etc.) yields
-/// `Err` so callers can tell "not mine" apart from "broken".
+/// decrypted with `receiver_keys` — the canonical "not addressed to me"
+/// signal, so callers can try multiple candidate keys without treating
+/// each miss as fatal. Every other failure (corrupted seal, malformed
+/// rumor JSON, invalid signatures, etc.) yields `Err` so callers can tell
+/// "not mine" apart from "broken".
+///
+/// Does **not** enforce `seal.pubkey == rumor.pubkey`: Mostro signs the
+/// seal with the identity key and authors the rumor with the per-trade
+/// key, so the two legitimately differ.
 pub async fn unwrap_message(
     event: &Event,
-    trade_keys: &Keys,
+    receiver_keys: &Keys,
 ) -> Result<Option<UnwrappedMessage>, MostroError> {
     if event.kind != Kind::GiftWrap {
         return Err(MostroError::MostroInternalErr(
@@ -158,20 +178,53 @@ pub async fn unwrap_message(
         ));
     }
 
-    let unwrapped = match nip59::extract_rumor(trade_keys, event).await {
-        Ok(u) => u,
-        // Outer NIP-44 decrypt failed — wrap was not for us.
-        Err(nip59::Error::Signer(_)) => return Ok(None),
-        Err(e) => {
-            return Err(MostroError::MostroInternalErr(ServiceError::NostrError(
-                e.to_string(),
-            )));
-        }
+    // Decrypt outer GiftWrap using (receiver_secret, ephemeral_pub).
+    // Failure here is the "not addressed to me" signal.
+    let seal_json = match nip44::decrypt(
+        receiver_keys.secret_key(),
+        &event.pubkey,
+        &event.content,
+    ) {
+        Ok(s) => s,
+        Err(_) => return Ok(None),
     };
 
-    let (message, sig_str): (Message, Option<String>) =
-        serde_json::from_str(&unwrapped.rumor.content)
-            .map_err(|_| MostroError::MostroInternalErr(ServiceError::MessageSerializationError))?;
+    let seal: Event = Event::from_json(&seal_json).map_err(|e| {
+        MostroError::MostroInternalErr(ServiceError::NostrError(format!(
+            "malformed seal JSON: {e}"
+        )))
+    })?;
+
+    if seal.kind != Kind::Seal {
+        return Err(MostroError::MostroInternalErr(
+            ServiceError::UnexpectedError("inner event is not a Seal".to_string()),
+        ));
+    }
+
+    seal.verify_signature()
+        .then_some(())
+        .ok_or_else(|| {
+            MostroError::MostroInternalErr(ServiceError::NostrError(
+                "invalid seal signature".to_string(),
+            ))
+        })?;
+
+    // Decrypt the seal content using (receiver_secret, seal.pubkey). In
+    // Mostro, seal.pubkey is the sender's identity key, which is also the
+    // key that performed the NIP-44 encryption in `wrap_message`.
+    let rumor_json = nip44::decrypt(receiver_keys.secret_key(), &seal.pubkey, &seal.content)
+        .map_err(|e| {
+            MostroError::MostroInternalErr(ServiceError::DecryptionError(e.to_string()))
+        })?;
+
+    let rumor: UnsignedEvent = UnsignedEvent::from_json(&rumor_json).map_err(|e| {
+        MostroError::MostroInternalErr(ServiceError::NostrError(format!(
+            "malformed rumor JSON: {e}"
+        )))
+    })?;
+
+    let (message, sig_str): (Message, Option<String>) = serde_json::from_str(&rumor.content)
+        .map_err(|_| MostroError::MostroInternalErr(ServiceError::MessageSerializationError))?;
 
     let signature = match sig_str {
         Some(s) => {
@@ -181,7 +234,7 @@ pub async fn unwrap_message(
                 )))
             })?;
             let message_json = message.as_json().map_err(MostroError::MostroInternalErr)?;
-            if !Message::verify_signature(message_json, unwrapped.sender, sig) {
+            if !Message::verify_signature(message_json, rumor.pubkey, sig) {
                 return Err(MostroError::MostroInternalErr(
                     ServiceError::UnexpectedError(
                         "rumor signature does not verify against sender".to_string(),
@@ -196,8 +249,9 @@ pub async fn unwrap_message(
     Ok(Some(UnwrappedMessage {
         message,
         signature,
-        sender: unwrapped.sender,
-        created_at: unwrapped.rumor.created_at,
+        sender: rumor.pubkey,
+        identity: seal.pubkey,
+        created_at: rumor.created_at,
     }))
 }
 
@@ -300,6 +354,7 @@ mod tests {
 
     #[tokio::test]
     async fn wrap_then_unwrap_roundtrip() {
+        let identity_keys = Keys::generate();
         let trade_keys = Keys::generate();
         let receiver_keys = Keys::generate();
 
@@ -307,6 +362,7 @@ mod tests {
 
         let wrapped = wrap_message(
             &message,
+            &identity_keys,
             &trade_keys,
             receiver_keys.public_key(),
             WrapOptions::default(),
@@ -326,6 +382,7 @@ mod tests {
             .expect("unwrap some");
 
         assert_eq!(unwrapped.sender, trade_keys.public_key());
+        assert_eq!(unwrapped.identity, identity_keys.public_key());
         assert_eq!(
             unwrapped.message.as_json().unwrap(),
             message.as_json().unwrap()
@@ -334,14 +391,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn full_privacy_mode_identity_equals_sender() {
+        // Caller that opts out of reputation passes trade_keys as identity.
+        let trade_keys = Keys::generate();
+        let receiver_keys = Keys::generate();
+
+        let wrapped = wrap_message(
+            &sample_order_message(Some(1)),
+            &trade_keys,
+            &trade_keys,
+            receiver_keys.public_key(),
+            WrapOptions::default(),
+        )
+        .await
+        .expect("wrap");
+
+        let unwrapped = unwrap_message(&wrapped, &receiver_keys)
+            .await
+            .expect("unwrap")
+            .expect("some");
+
+        assert_eq!(unwrapped.sender, trade_keys.public_key());
+        assert_eq!(unwrapped.identity, trade_keys.public_key());
+    }
+
+    #[tokio::test]
     async fn unwrap_with_corrupted_seal_returns_err() {
         let receiver_keys = Keys::generate();
         let ephemeral = Keys::generate();
 
-        // GiftWrap addressed to `receiver_keys` whose outer ciphertext
-        // decrypts successfully but yields a string that is not a valid
-        // seal Event JSON. `extract_rumor` must surface this as an error,
-        // not be silently absorbed as `Ok(None)`.
+        // GiftWrap whose outer ciphertext decrypts successfully but yields
+        // a string that is not a valid seal Event JSON. Must surface as
+        // Err, not be silently absorbed as Ok(None).
         let encrypted = nip44::encrypt(
             ephemeral.secret_key(),
             &receiver_keys.public_key(),
@@ -366,16 +447,17 @@ mod tests {
     // can inject a malformed or wrong-signature payload that `wrap_message`
     // would never emit.
     async fn wrap_with_raw_inner(
+        identity_keys: &Keys,
         trade_keys: &Keys,
         receiver: PublicKey,
         inner: (&Message, Option<String>),
     ) -> Event {
         let content = serde_json::to_string(&inner).unwrap();
         let rumor = EventBuilder::text_note(content).build(trade_keys.public_key());
-        let seal = EventBuilder::seal(trade_keys, &receiver, rumor)
+        let seal = EventBuilder::seal(identity_keys, &receiver, rumor)
             .await
             .unwrap()
-            .sign(trade_keys)
+            .sign(identity_keys)
             .await
             .unwrap();
         gift_wrap_from_seal_with_pow(&seal, receiver, 0, None).unwrap()
@@ -383,11 +465,13 @@ mod tests {
 
     #[tokio::test]
     async fn unwrap_with_malformed_signature_errors() {
+        let identity_keys = Keys::generate();
         let trade_keys = Keys::generate();
         let receiver_keys = Keys::generate();
         let msg = sample_order_message(Some(1));
 
         let wrapped = wrap_with_raw_inner(
+            &identity_keys,
             &trade_keys,
             receiver_keys.public_key(),
             (&msg, Some("not-a-hex-signature".to_string())),
@@ -403,6 +487,7 @@ mod tests {
 
     #[tokio::test]
     async fn unwrap_with_signature_for_other_content_errors() {
+        let identity_keys = Keys::generate();
         let trade_keys = Keys::generate();
         let receiver_keys = Keys::generate();
         let msg = sample_order_message(Some(1));
@@ -410,6 +495,7 @@ mod tests {
         let bogus = Message::sign("not the real message".to_string(), &trade_keys);
 
         let wrapped = wrap_with_raw_inner(
+            &identity_keys,
             &trade_keys,
             receiver_keys.public_key(),
             (&msg, Some(bogus.to_string())),
@@ -424,13 +510,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unwrap_with_wrong_trade_keys_returns_none() {
+    async fn unwrap_with_wrong_receiver_keys_returns_none() {
+        let identity_keys = Keys::generate();
         let trade_keys = Keys::generate();
         let receiver_keys = Keys::generate();
         let stranger_keys = Keys::generate();
 
         let wrapped = wrap_message(
             &sample_order_message(Some(1)),
+            &identity_keys,
             &trade_keys,
             receiver_keys.public_key(),
             WrapOptions::default(),
@@ -446,12 +534,14 @@ mod tests {
 
     #[tokio::test]
     async fn signature_is_verifiable_with_trade_pubkey() {
+        let identity_keys = Keys::generate();
         let trade_keys = Keys::generate();
         let receiver_keys = Keys::generate();
         let message = sample_order_message(Some(7));
 
         let wrapped = wrap_message(
             &message,
+            &identity_keys,
             &trade_keys,
             receiver_keys.public_key(),
             WrapOptions::default(),
@@ -475,11 +565,13 @@ mod tests {
 
     #[tokio::test]
     async fn unsigned_wrap_has_no_signature() {
+        let identity_keys = Keys::generate();
         let trade_keys = Keys::generate();
         let receiver_keys = Keys::generate();
 
         let wrapped = wrap_message(
             &sample_order_message(Some(3)),
+            &identity_keys,
             &trade_keys,
             receiver_keys.public_key(),
             WrapOptions {
@@ -499,12 +591,14 @@ mod tests {
 
     #[tokio::test]
     async fn expiration_tag_is_set_when_provided() {
+        let identity_keys = Keys::generate();
         let trade_keys = Keys::generate();
         let receiver_keys = Keys::generate();
         let exp = Timestamp::from_secs(Timestamp::now().as_secs() + 3600);
 
         let wrapped = wrap_message(
             &sample_order_message(Some(1)),
+            &identity_keys,
             &trade_keys,
             receiver_keys.public_key(),
             WrapOptions {

--- a/src/nip59.rs
+++ b/src/nip59.rs
@@ -180,11 +180,8 @@ pub async fn unwrap_message(
 
     // Decrypt outer GiftWrap using (receiver_secret, ephemeral_pub).
     // Failure here is the "not addressed to me" signal.
-    let seal_json = match nip44::decrypt(
-        receiver_keys.secret_key(),
-        &event.pubkey,
-        &event.content,
-    ) {
+    let seal_json = match nip44::decrypt(receiver_keys.secret_key(), &event.pubkey, &event.content)
+    {
         Ok(s) => s,
         Err(_) => return Ok(None),
     };
@@ -201,13 +198,11 @@ pub async fn unwrap_message(
         ));
     }
 
-    seal.verify_signature()
-        .then_some(())
-        .ok_or_else(|| {
-            MostroError::MostroInternalErr(ServiceError::NostrError(
-                "invalid seal signature".to_string(),
-            ))
-        })?;
+    seal.verify_signature().then_some(()).ok_or_else(|| {
+        MostroError::MostroInternalErr(ServiceError::NostrError(
+            "invalid seal signature".to_string(),
+        ))
+    })?;
 
     // Decrypt the seal content using (receiver_secret, seal.pubkey). In
     // Mostro, seal.pubkey is the sender's identity key, which is also the
@@ -222,6 +217,12 @@ pub async fn unwrap_message(
             "malformed rumor JSON: {e}"
         )))
     })?;
+
+    if rumor.kind != Kind::TextNote {
+        return Err(MostroError::MostroInternalErr(
+            ServiceError::UnexpectedError("rumor is not a TextNote".to_string()),
+        ));
+    }
 
     let (message, sig_str): (Message, Option<String>) = serde_json::from_str(&rumor.content)
         .map_err(|_| MostroError::MostroInternalErr(ServiceError::MessageSerializationError))?;


### PR DESCRIPTION
Mostro's protocol signs the seal (kind 13) with a long-lived identity key while authoring the rumor (kind 1) with a per-trade key. nostr-sdk 0.44's extract_rumor enforces seal.pubkey == rumor.pubkey, which rejects this legitimate split.

- wrap_message now takes identity_keys and trade_keys. The seal is NIP-44 encrypted and signed with identity_keys; the rumor is authored by trade_keys and the inner tuple signature is produced with trade_keys. Full-privacy mode: pass the same Keys for both.
- unwrap_message no longer calls nip59::extract_rumor. It decrypts the outer layer and the seal directly with nip44::decrypt, verifies the seal signature, and does not enforce seal.pubkey == rumor.pubkey.
- UnwrappedMessage gains an identity field (seal signer) alongside sender (rumor author / trade key).
- Tests updated; new full_privacy_mode_identity_equals_sender covers the mode where identity and trade are the same keypair.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced privacy features supporting separate identity and sender mechanisms.
  * Updated encryption and decryption mechanism with revised key handling process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->