### PR TITLE
feat(chat): add P2P chat protocol module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## What's Changed in Unreleased
+
+### 🚀 Features
+
+
+* add `chat` module: ECDH-derived `SharedKey`, NIP-44 wrap/unwrap of P2P chat gift wraps, and a relay `chat_filter` for buyer/seller and admin/party conversations.
+
 ## Verifying the Release
 In order to verify the release, you'll need to have gpg or gpg2 installed on your system. Once you've obtained a copy (and hopefully verified that as well), you'll first need to import the keys that have signed this release if you haven't done so already:
 ```bash

--- a/src/chat/filter.rs
+++ b/src/chat/filter.rs
@@ -1,0 +1,63 @@
+//! Build a Nostr relay filter for Mostro P2P chat gift wraps.
+//!
+//! Chat gift wraps are addressable by the shared key's public key (carried
+//! in the outer `p` tag), so a single filter retrieves both directions of
+//! the conversation regardless of which trade key authored each message.
+
+use nostr_sdk::prelude::*;
+
+/// Default lookback window applied by [`chat_filter`] (7 days).
+///
+/// Mostro chat sessions are short-lived (a trade lasts at most a few days),
+/// so a one-week window covers active disputes without dragging back
+/// arbitrarily old wraps.
+pub const CHAT_DEFAULT_LOOKBACK_SECS: u64 = 7 * 24 * 60 * 60;
+
+/// Create a Nostr relay filter for chat gift wraps addressed to a shared
+/// public key.
+///
+/// The returned filter matches:
+///
+/// * `kind == 1059` ([`Kind::GiftWrap`]),
+/// * presence of a `p` tag equal to `shared_pubkey`,
+/// * `created_at >= now - CHAT_DEFAULT_LOOKBACK_SECS`.
+///
+/// Callers can chain extra constraints (e.g. `.limit(...)` or override
+/// `.since(...)`) before subscribing.
+pub fn chat_filter(shared_pubkey: PublicKey) -> Filter {
+    let since = Timestamp::now()
+        .as_secs()
+        .saturating_sub(CHAT_DEFAULT_LOOKBACK_SECS);
+    Filter::new()
+        .kind(Kind::GiftWrap)
+        .pubkey(shared_pubkey)
+        .since(Timestamp::from_secs(since))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filter_targets_gift_wrap_kind_and_pubkey() {
+        let pk = Keys::generate().public_key();
+        let filter = chat_filter(pk);
+        let json = serde_json::to_value(&filter).expect("filter json");
+
+        let kinds = json.get("kinds").expect("kinds present");
+        assert!(kinds
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|k| k.as_u64() == Some(1059)));
+
+        let p = json.get("#p").expect("#p tag present");
+        assert!(p
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|v| v.as_str() == Some(&pk.to_hex())));
+
+        assert!(json.get("since").is_some());
+    }
+}

--- a/src/chat/mod.rs
+++ b/src/chat/mod.rs
@@ -1,0 +1,180 @@
+//! Mostro P2P chat protocol primitives.
+//!
+//! Mostro reuses the NIP-59 GiftWrap envelope to carry a second, lighter
+//! channel: direct buyer/seller chat during a trade and admin/party chat
+//! during a dispute. Unlike protocol messages — which are addressed to a
+//! Mostro node and use the dual identity/trade key scheme of
+//! [`crate::nip59`] — chat envelopes are addressed to a per-channel
+//! **shared key** that both parties derive via ECDH from their trade keys.
+//!
+//! The on-the-wire shape is intentionally simple:
+//!
+//! ```text
+//! Plain-text message
+//!     -> kind 1 TextNote signed by sender_trade_keys (inner)
+//!     -> NIP-44 v2 encrypt to shared_pubkey using an ephemeral key
+//!     -> kind 1059 GiftWrap with `p` = shared_pubkey, signed ephemerally
+//! ```
+//!
+//! Both parties can fetch and decrypt every wrap addressed to the shared
+//! key, and the inner event's signature carries the real sender's trade
+//! pubkey so each side can render the conversation correctly without
+//! exchanging extra metadata.
+//!
+//! This module is **pure protocol**: it derives shared keys, builds and
+//! parses envelopes, and constructs the relay filter. It does not manage
+//! relays, subscriptions, persistence or higher-level workflows — those
+//! belong to the client.
+//!
+//! ## Quick start
+//!
+//! ```no_run
+//! # async fn run() -> Result<(), mostro_core::error::MostroError> {
+//! use mostro_core::chat::{chat_filter, wrap_chat_message, unwrap_chat_message, SharedKey};
+//! use nostr_sdk::prelude::*;
+//!
+//! let alice = Keys::generate();
+//! let bob_pubkey = Keys::generate().public_key();
+//!
+//! let shared = SharedKey::derive(alice.secret_key(), &bob_pubkey)?;
+//! let event = wrap_chat_message(&alice, &shared.public_key(), "hi bob").await?;
+//!
+//! // ...publish `event` to relays, fetch incoming wraps with `chat_filter(...)`,
+//! // then on the receiving side:
+//! let chat = unwrap_chat_message(shared.keys(), &event).await?;
+//! assert_eq!(chat.content, "hi bob");
+//! # Ok(()) }
+//! ```
+
+mod filter;
+mod shared_key;
+mod unwrap;
+mod wrap;
+
+pub use filter::{chat_filter, CHAT_DEFAULT_LOOKBACK_SECS};
+pub use shared_key::SharedKey;
+pub use unwrap::{unwrap_chat_message, ChatMessage};
+pub use wrap::wrap_chat_message;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nostr_sdk::nips::nip44;
+    use nostr_sdk::prelude::*;
+
+    fn shared_pair() -> (Keys, Keys, SharedKey, SharedKey) {
+        let alice = Keys::generate();
+        let bob = Keys::generate();
+        let alice_shared = SharedKey::derive(alice.secret_key(), &bob.public_key()).unwrap();
+        let bob_shared = SharedKey::derive(bob.secret_key(), &alice.public_key()).unwrap();
+        (alice, bob, alice_shared, bob_shared)
+    }
+
+    #[tokio::test]
+    async fn wrap_and_unwrap_roundtrip() {
+        let (alice, _bob, alice_shared, bob_shared) = shared_pair();
+        let body = "hello from alice";
+
+        let event = wrap_chat_message(&alice, &alice_shared.public_key(), body)
+            .await
+            .expect("wrap");
+
+        assert_eq!(event.kind, Kind::GiftWrap);
+        assert!(event
+            .tags
+            .public_keys()
+            .any(|pk| *pk == alice_shared.public_key()));
+
+        let decoded = unwrap_chat_message(bob_shared.keys(), &event)
+            .await
+            .expect("unwrap");
+
+        assert_eq!(decoded.content, body);
+        assert_eq!(decoded.sender, alice.public_key());
+    }
+
+    #[tokio::test]
+    async fn unwrap_with_wrong_shared_key_fails() {
+        let (alice, _bob, alice_shared, _bob_shared) = shared_pair();
+        let intruder = Keys::generate();
+        let intruder_shared =
+            SharedKey::derive(intruder.secret_key(), &Keys::generate().public_key()).unwrap();
+
+        let event = wrap_chat_message(&alice, &alice_shared.public_key(), "for bob only")
+            .await
+            .expect("wrap");
+
+        let err = unwrap_chat_message(intruder_shared.keys(), &event)
+            .await
+            .expect_err("must not decrypt with foreign shared key");
+        assert!(matches!(
+            err,
+            crate::error::MostroError::MostroInternalErr(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn unwrap_tampered_event_fails() {
+        let (_alice, _bob, alice_shared, bob_shared) = shared_pair();
+
+        // Build a wrap whose inner ciphertext is the encryption of an event
+        // signed by an *impostor*, not by `alice`. The outer envelope is
+        // perfectly valid (ephemeral key signs it), but the inner signature
+        // must not verify against the rumor pubkey.
+        let impostor = Keys::generate();
+        let inner = EventBuilder::text_note("forged")
+            .build(impostor.public_key())
+            .sign(&impostor)
+            .await
+            .unwrap();
+
+        // Mutate the signed event JSON so the signature no longer matches
+        // its content — `verify()` should reject it.
+        let mut json: serde_json::Value = serde_json::from_str(&inner.as_json()).unwrap();
+        json["content"] = serde_json::Value::String("tampered".to_string());
+        let tampered_inner = json.to_string();
+
+        let ephemeral = Keys::generate();
+        let encrypted = nip44::encrypt(
+            ephemeral.secret_key(),
+            &alice_shared.public_key(),
+            tampered_inner,
+            nip44::Version::V2,
+        )
+        .unwrap();
+        let event = EventBuilder::new(Kind::GiftWrap, encrypted)
+            .tag(Tag::public_key(alice_shared.public_key()))
+            .sign_with_keys(&ephemeral)
+            .unwrap();
+
+        let err = unwrap_chat_message(bob_shared.keys(), &event)
+            .await
+            .expect_err("tampered inner must not verify");
+        assert!(matches!(
+            err,
+            crate::error::MostroError::MostroInternalErr(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn unwrap_rejects_non_giftwrap_event() {
+        let alice = Keys::generate();
+        let other = Keys::generate();
+        let shared = SharedKey::derive(alice.secret_key(), &other.public_key()).unwrap();
+
+        // A plain text note is the wrong kind for the outer envelope.
+        let bogus = EventBuilder::text_note("not a wrap")
+            .build(alice.public_key())
+            .sign(&alice)
+            .await
+            .unwrap();
+
+        let err = unwrap_chat_message(shared.keys(), &bogus)
+            .await
+            .expect_err("non-giftwrap must error");
+        assert!(matches!(
+            err,
+            crate::error::MostroError::MostroInternalErr(_)
+        ));
+    }
+}

--- a/src/chat/shared_key.rs
+++ b/src/chat/shared_key.rs
@@ -1,0 +1,133 @@
+//! ECDH-derived shared key used as the addressable identity of a Mostro
+//! P2P chat channel.
+//!
+//! The two parties of a chat (buyer/seller during a trade or admin/party
+//! during a dispute) each compute the same `SharedKey` from their own trade
+//! secret key and the counterparty's trade public key, so both can encrypt
+//! and decrypt the conversation, and so relays can route gift wraps through
+//! a `p` tag bound to the shared public key — without leaking either real
+//! pubkey on the wire.
+
+use nostr_sdk::prelude::*;
+
+use crate::error::{MostroError, ServiceError};
+
+/// Shared key derived via ECDH between two parties' trade keys.
+///
+/// Internally a `Keys` instance whose secret is the 32-byte ECDH output of
+/// `(local_secret, counterparty_pubkey)`. Both sides of the conversation
+/// derive an identical value and therefore an identical public key, which
+/// is what gift wraps are addressed to.
+#[derive(Debug, Clone)]
+pub struct SharedKey(Keys);
+
+impl SharedKey {
+    /// Derive a shared key from a local secret key and the counterparty's
+    /// public key using the secp256k1 ECDH primitive exposed by
+    /// [`nostr_sdk::util::generate_shared_key`].
+    ///
+    /// Both peers obtain the same `SharedKey` by swapping arguments
+    /// (`A.derive(a_sk, b_pk) == B.derive(b_sk, a_pk)`).
+    pub fn derive(secret: &SecretKey, counterparty: &PublicKey) -> Result<Self, MostroError> {
+        let bytes = nostr_sdk::util::generate_shared_key(secret, counterparty).map_err(|e| {
+            MostroError::MostroInternalErr(ServiceError::EncryptionError(format!(
+                "shared key derivation failed: {e}"
+            )))
+        })?;
+        let secret = SecretKey::from_slice(&bytes).map_err(|e| {
+            MostroError::MostroInternalErr(ServiceError::EncryptionError(format!(
+                "invalid shared secret: {e}"
+            )))
+        })?;
+        Ok(Self(Keys::new(secret)))
+    }
+
+    /// Build a `SharedKey` from an already-derived `Keys` value.
+    ///
+    /// Useful when a client persists a freshly-generated `Keys` instead of
+    /// re-deriving it on every load.
+    pub fn from_keys(keys: Keys) -> Self {
+        Self(keys)
+    }
+
+    /// Borrow the underlying `Keys`.
+    pub fn keys(&self) -> &Keys {
+        &self.0
+    }
+
+    /// Public key of this shared key — the value used as the `p` tag on
+    /// every gift wrap belonging to the channel.
+    pub fn public_key(&self) -> PublicKey {
+        self.0.public_key()
+    }
+
+    /// Borrow the underlying secret key.
+    pub fn secret_key(&self) -> &SecretKey {
+        self.0.secret_key()
+    }
+
+    /// Serialize the secret as a lower-case hex string suitable for client
+    /// persistence. Pair with [`SharedKey::from_hex`] to round-trip.
+    pub fn to_hex(&self) -> String {
+        self.0.secret_key().to_secret_hex()
+    }
+
+    /// Rebuild a `SharedKey` from a hex-encoded secret previously produced
+    /// by [`SharedKey::to_hex`].
+    pub fn from_hex(hex: &str) -> Result<Self, MostroError> {
+        let secret = SecretKey::from_hex(hex).map_err(|e| {
+            MostroError::MostroInternalErr(ServiceError::EncryptionError(format!(
+                "invalid shared key hex: {e}"
+            )))
+        })?;
+        Ok(Self(Keys::new(secret)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derive_is_symmetric_between_peers() {
+        let alice = Keys::generate();
+        let bob = Keys::generate();
+
+        let from_alice = SharedKey::derive(alice.secret_key(), &bob.public_key()).unwrap();
+        let from_bob = SharedKey::derive(bob.secret_key(), &alice.public_key()).unwrap();
+
+        assert_eq!(from_alice.public_key(), from_bob.public_key());
+        assert_eq!(from_alice.to_hex(), from_bob.to_hex());
+    }
+
+    #[test]
+    fn derive_shared_key_hex_roundtrip() {
+        let alice = Keys::generate();
+        let bob = Keys::generate();
+        let derived = SharedKey::derive(alice.secret_key(), &bob.public_key()).unwrap();
+
+        let hex = derived.to_hex();
+        let restored = SharedKey::from_hex(&hex).unwrap();
+
+        assert_eq!(derived.public_key(), restored.public_key());
+        assert_eq!(derived.to_hex(), restored.to_hex());
+    }
+
+    #[test]
+    fn derive_shared_key_different_peers_produce_different_keys() {
+        let alice = Keys::generate();
+        let bob = Keys::generate();
+        let carol = Keys::generate();
+
+        let with_bob = SharedKey::derive(alice.secret_key(), &bob.public_key()).unwrap();
+        let with_carol = SharedKey::derive(alice.secret_key(), &carol.public_key()).unwrap();
+
+        assert_ne!(with_bob.public_key(), with_carol.public_key());
+    }
+
+    #[test]
+    fn from_hex_rejects_invalid_input() {
+        let err = SharedKey::from_hex("not-a-hex-string").unwrap_err();
+        assert!(matches!(err, MostroError::MostroInternalErr(_)));
+    }
+}

--- a/src/chat/unwrap.rs
+++ b/src/chat/unwrap.rs
@@ -1,0 +1,70 @@
+//! Decrypt a Mostro P2P chat gift wrap and verify its inner signature.
+
+use nostr_sdk::nips::nip44;
+use nostr_sdk::prelude::*;
+
+use crate::error::{MostroError, ServiceError};
+
+/// A decrypted P2P chat message.
+#[derive(Debug, Clone)]
+pub struct ChatMessage {
+    /// Plain-text body of the inner kind 1 event.
+    pub content: String,
+    /// Trade public key of the sender, taken from the inner event's
+    /// signature — already verified by [`unwrap_chat_message`].
+    pub sender: PublicKey,
+    /// `created_at` of the inner kind 1 event.
+    pub created_at: Timestamp,
+}
+
+/// Unwrap a Mostro P2P chat gift wrap.
+///
+/// * `shared_keys` — the `Keys` instance derived from the channel's
+///   [`SharedKey`](super::SharedKey); the secret half is needed to NIP-44
+///   decrypt the outer ciphertext.
+/// * `event` — a kind 1059 event previously fetched from a relay.
+///
+/// On success the inner kind 1 event's signature is verified before
+/// returning, so the [`ChatMessage::sender`] field can be trusted as the
+/// authentic author of the message.
+pub async fn unwrap_chat_message(
+    shared_keys: &Keys,
+    event: &Event,
+) -> Result<ChatMessage, MostroError> {
+    if event.kind != Kind::GiftWrap {
+        return Err(MostroError::MostroInternalErr(
+            ServiceError::UnexpectedError("event is not a GiftWrap".to_string()),
+        ));
+    }
+
+    let decrypted = nip44::decrypt(shared_keys.secret_key(), &event.pubkey, &event.content)
+        .map_err(|e| {
+            MostroError::MostroInternalErr(ServiceError::DecryptionError(format!(
+                "shared-key decrypt failed: {e}"
+            )))
+        })?;
+
+    let inner = Event::from_json(&decrypted).map_err(|e| {
+        MostroError::MostroInternalErr(ServiceError::NostrError(format!(
+            "malformed inner chat event: {e}"
+        )))
+    })?;
+
+    if inner.kind != Kind::TextNote {
+        return Err(MostroError::MostroInternalErr(
+            ServiceError::UnexpectedError("inner chat event is not a TextNote".to_string()),
+        ));
+    }
+
+    inner.verify().map_err(|e| {
+        MostroError::MostroInternalErr(ServiceError::NostrError(format!(
+            "invalid inner chat signature: {e}"
+        )))
+    })?;
+
+    Ok(ChatMessage {
+        content: inner.content,
+        sender: inner.pubkey,
+        created_at: inner.created_at,
+    })
+}

--- a/src/chat/wrap.rs
+++ b/src/chat/wrap.rs
@@ -1,0 +1,53 @@
+//! Build a Mostro P2P chat gift wrap.
+//!
+//! The wire format is a non-standard NIP-59 envelope: a kind 1 text note
+//! signed by the sender's trade key is encrypted with NIP-44 v2 using an
+//! ephemeral key as the encryption side and the **shared key's public key**
+//! as the recipient. The outer kind 1059 event carries that ciphertext, a
+//! `p` tag pointing at the shared pubkey for relay routing, and is signed
+//! with the same ephemeral key.
+//!
+//! See <https://mostro.network/protocol/chat.html> for the protocol spec.
+
+use nostr_sdk::nips::{nip44, nip59};
+use nostr_sdk::prelude::*;
+
+use crate::error::{MostroError, ServiceError};
+
+/// Wrap a plain-text chat message into a Mostro P2P gift wrap (kind 1059).
+///
+/// * `sender_trade_keys` — the sender's per-trade keys; sign the inner kind 1
+///   so the receiver can verify authorship.
+/// * `shared_pubkey` — public key of the [`SharedKey`](super::SharedKey)
+///   shared by the two chat parties; used as the NIP-44 recipient and as
+///   the value of the outer `p` tag.
+/// * `message` — the chat content to deliver.
+///
+/// The outer `created_at` is randomized within
+/// [`nip59::RANGE_RANDOM_TIMESTAMP_TWEAK`] to defeat timing correlation.
+pub async fn wrap_chat_message(
+    sender_trade_keys: &Keys,
+    shared_pubkey: &PublicKey,
+    message: &str,
+) -> Result<Event, MostroError> {
+    let inner = EventBuilder::text_note(message)
+        .build(sender_trade_keys.public_key())
+        .sign(sender_trade_keys)
+        .await
+        .map_err(|e| MostroError::MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
+
+    let ephemeral = Keys::generate();
+    let encrypted = nip44::encrypt(
+        ephemeral.secret_key(),
+        shared_pubkey,
+        inner.as_json(),
+        nip44::Version::V2,
+    )
+    .map_err(|e| MostroError::MostroInternalErr(ServiceError::EncryptionError(e.to_string())))?;
+
+    EventBuilder::new(Kind::GiftWrap, encrypted)
+        .tag(Tag::public_key(*shared_pubkey))
+        .custom_created_at(Timestamp::tweaked(nip59::RANGE_RANDOM_TIMESTAMP_TWEAK))
+        .sign_with_keys(&ephemeral)
+        .map_err(|e| MostroError::MostroInternalErr(ServiceError::NostrError(e.to_string())))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,8 @@
 //! * [`rating`] — Nostr-tag-encoded reputation helper.
 //! * [`error`] — unified error taxonomy ([`MostroError`], [`ServiceError`],
 //!   [`CantDoReason`]).
-//! * [`nip59`] — GiftWrap wrap/unwrap transport.
+//! * [`nip59`] — GiftWrap wrap/unwrap transport for protocol messages.
+//! * [`chat`] — P2P buyer/seller and admin/party chat envelope.
 //! * [`prelude`] — convenience re-exports.
 //!
 //! [`MostroError`]: crate::error::MostroError
@@ -74,6 +75,7 @@
 #![doc(html_root_url = "https://docs.rs/mostro-core")]
 #![warn(missing_docs)]
 
+pub mod chat;
 pub mod dispute;
 pub mod error;
 pub mod message;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -10,6 +10,10 @@
 //! It also defines the Nostr event kinds used by the protocol and the minimum
 //! and maximum rating bounds.
 
+pub use crate::chat::{
+    chat_filter, unwrap_chat_message, wrap_chat_message, ChatMessage, SharedKey,
+    CHAT_DEFAULT_LOOKBACK_SECS,
+};
 pub use crate::dispute::{Dispute, SolverDisputeInfo, Status as DisputeStatus};
 pub use crate::error::{CantDoReason, MostroError, ServiceError};
 pub use crate::message::{


### PR DESCRIPTION
## Summary

Adds `mostro_core::chat`, a pure-protocol module for the Mostro P2P chat channel used between buyer/seller during a trade and admin/party during a dispute. Until now this wire format only existed inside individual clients (notably mostrix's `src/util/chat_utils.rs`); centralizing it here means future clients can drop in the primitives instead of reimplementing NIP-59 + ECDH glue.

The module is wire-compatible with the existing mostrix implementation, so events produced here can be decrypted by current clients and vice-versa. Spec: <https://mostro.network/protocol/chat.html>.

## API

* `SharedKey` — ECDH-derived channel key.
  * `derive(&SecretKey, &PublicKey) -> Result<Self, MostroError>` (uses `nostr_sdk::util::generate_shared_key`)
  * `to_hex` / `from_hex` for client-side persistence
  * `public_key`, `secret_key`, `keys`
* `wrap_chat_message(&Keys, &PublicKey, &str) -> Result<Event, MostroError>` — kind 1 `TextNote` signed by the sender's trade key, NIP-44 v2 encrypted to the shared pubkey via an ephemeral key, wrapped in a kind 1059 `GiftWrap` with a `p` tag pointing at the shared pubkey. Outer `created_at` randomized via `nip59::RANGE_RANDOM_TIMESTAMP_TWEAK`.
* `unwrap_chat_message(&Keys, &Event) -> Result<ChatMessage, MostroError>` — decrypts with the shared key and verifies the inner signature before returning `{ content, sender, created_at }`.
* `chat_filter(PublicKey) -> Filter` — kind 1059 + `#p` = shared pubkey + 7-day `since` (`CHAT_DEFAULT_LOOKBACK_SECS`).

All public items are documented; types are re-exported through `prelude`.

## Out of scope (intentionally)

No UI, persistence, relay management, counterparty resolution from order state, or admin-specific flow logic — the same primitives serve user-user and admin-party chat. Clients keep that orchestration.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` — 47 unit tests + 4 doc-tests pass; 9 new chat tests cover:
  - shared-key derive symmetry between peers
  - hex round-trip
  - distinct counterparties produce distinct shared keys
  - `from_hex` rejects invalid input
  - filter shape (kind, `#p`, `since`)
  - wrap/unwrap round-trip with content + sender match
  - unwrap with wrong shared key fails
  - unwrap of a tampered inner event fails
  - unwrap of a non-GiftWrap event fails
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [ ] Cross-compatibility with mostrix (manual smoke test recommended before release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added encrypted P2P chat messaging with ECDH-based key derivation.
  * Implemented NIP-44 message encryption and decryption for secure communications.
  * Added relay filtering for buyer/seller and admin/party chat conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->