### PR TITLE
feat: add Action::PayBondInvoice and Status::WaitingTakerBond

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -74,6 +74,13 @@ pub enum Action {
     /// Request the taker to pay a Lightning invoice.
     /// Payload: [`Payload::PaymentRequest`].
     PayInvoice,
+    /// Mostro delivers the bolt11 hold invoice that the taker must pay as
+    /// their anti-abuse bond. Same payload shape and direction as
+    /// [`Action::PayInvoice`] (Mostro → user); only the discriminator
+    /// differs so clients can tell the bond invoice apart from the trade
+    /// hold invoice that follows.
+    /// Payload: [`Payload::PaymentRequest`].
+    PayBondInvoice,
     /// Buyer notifies Mostro that fiat was sent.
     FiatSent,
     /// Mostro acknowledges the fiat-sent notification to the seller.
@@ -515,9 +522,10 @@ pub enum Payload {
     Order(SmallOrder),
     /// Lightning payment request plus optional amount override.
     ///
-    /// Used by [`Action::PayInvoice`], [`Action::AddInvoice`] and
-    /// [`Action::TakeSell`]. The [`SmallOrder`] carries the matching order
-    /// when relevant; the `String` is a BOLT-11 invoice.
+    /// Used by [`Action::PayInvoice`], [`Action::PayBondInvoice`],
+    /// [`Action::AddInvoice`] and [`Action::TakeSell`]. The [`SmallOrder`]
+    /// carries the matching order when relevant; the `String` is a BOLT-11
+    /// invoice.
     PaymentRequest(Option<SmallOrder>, String, Option<Amount>),
     /// Free-form text message used by DMs.
     TextMessage(String),
@@ -623,7 +631,7 @@ impl MessageKind {
     pub fn verify(&self) -> bool {
         match &self.action {
             Action::NewOrder => matches!(&self.payload, Some(Payload::Order(_))),
-            Action::PayInvoice | Action::AddInvoice => {
+            Action::PayInvoice | Action::PayBondInvoice | Action::AddInvoice => {
                 if self.id.is_none() {
                     return false;
                 }
@@ -1264,6 +1272,7 @@ mod test {
             Action::TakeSell,
             Action::TakeBuy,
             Action::PayInvoice,
+            Action::PayBondInvoice,
             Action::FiatSent,
             Action::FiatSentOk,
             Action::Release,
@@ -1368,6 +1377,66 @@ mod test {
         );
         let msg = Message::from_json(&json).unwrap();
         assert!(msg.verify());
+    }
+
+    #[test]
+    fn test_pay_bond_invoice_wire_format_and_verify() {
+        let uuid = uuid!("308e1272-d5f4-47e6-bd97-3504baea9c23");
+        let bolt11 = "lnbcrt78510n1pj59wmepp50677g8tffdqa2p8882y0x6newny5vtz0hjuyngdwv226nanv4uzsdqqcqzzsxqyz5vqsp5skn973360gp4yhlpmefwvul5hs58lkkl3u3ujvt57elmp4zugp4q9qyyssqw4nzlr72w28k4waycf27qvgzc9sp79sqlw83j56txltz4va44j7jda23ydcujj9y5k6k0rn5ms84w8wmcmcyk5g3mhpqepf7envhdccp72nz6e".to_string();
+
+        let msg = Message::Order(MessageKind::new(
+            Some(uuid),
+            Some(1),
+            Some(2),
+            Action::PayBondInvoice,
+            Some(Payload::PaymentRequest(None, bolt11.clone(), None)),
+        ));
+        assert!(msg.verify());
+
+        // Wire format must use the kebab-case discriminator.
+        let json = msg.as_json().unwrap();
+        assert!(
+            json.contains("\"action\":\"pay-bond-invoice\""),
+            "expected kebab-case discriminator, got: {json}"
+        );
+
+        // Roundtrip preserves the variant.
+        let decoded = Message::from_json(&json).unwrap();
+        assert!(decoded.verify());
+        assert!(matches!(
+            decoded.inner_action(),
+            Some(Action::PayBondInvoice)
+        ));
+
+        // Same id / payload constraints as PayInvoice: missing id is invalid.
+        let no_id = Message::Order(MessageKind::new(
+            None,
+            Some(1),
+            Some(2),
+            Action::PayBondInvoice,
+            Some(Payload::PaymentRequest(None, bolt11.clone(), None)),
+        ));
+        assert!(!no_id.verify());
+
+        // Wrong payload shape is rejected.
+        let wrong_payload = Message::Order(MessageKind::new(
+            Some(uuid),
+            Some(1),
+            Some(2),
+            Action::PayBondInvoice,
+            Some(Payload::TextMessage("nope".to_string())),
+        ));
+        assert!(!wrong_payload.verify());
+
+        // Missing payload is rejected (PaymentRequest is required).
+        let no_payload = Message::Order(MessageKind::new(
+            Some(uuid),
+            Some(1),
+            Some(2),
+            Action::PayBondInvoice,
+            None,
+        ));
+        assert!(!no_payload.verify());
     }
 
     #[test]

--- a/src/order.rs
+++ b/src/order.rs
@@ -87,6 +87,11 @@ pub enum Status {
     WaitingBuyerInvoice,
     /// Waiting for the seller to pay the hold invoice.
     WaitingPayment,
+    /// Order has been matched to a taker but Mostro is awaiting the taker's
+    /// bond hold-invoice payment before starting the trade flow. Distinct
+    /// from [`Status::Pending`] (advertised, no taker yet) and from
+    /// [`Status::WaitingPayment`] (trade escrow expected from the seller).
+    WaitingTakerBond,
     /// Both parties agreed to cooperatively cancel the trade.
     CooperativelyCanceled,
     /// Order has been taken and the trade is in progress.
@@ -109,6 +114,7 @@ impl Display for Status {
             Status::Success => write!(f, "success"),
             Status::WaitingBuyerInvoice => write!(f, "waiting-buyer-invoice"),
             Status::WaitingPayment => write!(f, "waiting-payment"),
+            Status::WaitingTakerBond => write!(f, "waiting-taker-bond"),
             Status::CooperativelyCanceled => write!(f, "cooperatively-canceled"),
             Status::InProgress => write!(f, "in-progress"),
         }
@@ -133,6 +139,7 @@ impl FromStr for Status {
             "success" => std::result::Result::Ok(Self::Success),
             "waiting-buyer-invoice" => std::result::Result::Ok(Self::WaitingBuyerInvoice),
             "waiting-payment" => std::result::Result::Ok(Self::WaitingPayment),
+            "waiting-taker-bond" => std::result::Result::Ok(Self::WaitingTakerBond),
             "cooperatively-canceled" => std::result::Result::Ok(Self::CooperativelyCanceled),
             "in-progress" => std::result::Result::Ok(Self::InProgress),
             _ => Err(()),
@@ -758,6 +765,20 @@ mod tests {
         assert_eq!(Status::CompletedByAdmin.to_string(), "completed-by-admin");
         assert_eq!(Status::FiatSent.to_string(), "fiat-sent");
         assert_ne!(Status::Pending.to_string(), "Pending");
+    }
+
+    #[test]
+    fn test_status_waiting_taker_bond_roundtrip() {
+        assert_eq!(Status::WaitingTakerBond.to_string(), "waiting-taker-bond");
+        assert_eq!(
+            Status::from_str("waiting-taker-bond").unwrap(),
+            Status::WaitingTakerBond
+        );
+        // serde representation must match the string form.
+        let json = serde_json::to_string(&Status::WaitingTakerBond).unwrap();
+        assert_eq!(json, "\"waiting-taker-bond\"");
+        let back: Status = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, Status::WaitingTakerBond);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Phase 1.5 of the [anti-abuse bond rollout](https://github.com/MostroP2P/mostro/blob/docs/anti-abuse-bond-decoupled-slash/docs/ANTI_ABUSE_BOND.md) retires the `PayInvoice` / `Pending` reuse used by Phase 1 to deliver the taker's bond. Dedicated wire variants let clients tell the bond hold-invoice apart from the trade hold-invoice that follows — important for the seller-as-taker (buy-order taken) case where the same user receives two consecutive payment requests and currently has to disambiguate via memo / hash heuristics.

- **`Action::PayBondInvoice`** (`"pay-bond-invoice"`) — Mostro → user, same payload shape as `PayInvoice` (`Payload::PaymentRequest` carrying the bolt11). Only the discriminator differs.
- **`Status::WaitingTakerBond`** (`"waiting-taker-bond"`) — order matched to a taker, awaiting the taker's bond payment. Distinct from `Pending` (advertised, no taker yet) and `WaitingPayment` (seller's trade escrow).

Both additions are serde-compatible: clients ignoring unknown variants keep working. The downstream `mostro` daemon will pin to this minor version in its Phase 1.5 PR.

### Naming note

The variant is `PayBondInvoice` (not `AddBondInvoice`) to match `PayInvoice`'s direction (Mostro → user, ""pay this bolt11""). `AddInvoice` already means the opposite direction (user → Mostro, ""here's my payout bolt11""), so `Add*` would be inconsistent.

### Validation in `MessageKind::verify`

`PayBondInvoice` shares the `PayInvoice | AddInvoice` arm: requires `id` to be present and a `Payload::PaymentRequest` payload. Direction is enforced by the daemon's action handlers, same as `PayInvoice`.

## Test plan

- [x] `cargo test --all-features` — 53 tests pass, including 2 new ones.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt` — clean.
- [x] New roundtrip test asserts `\"action\":\"pay-bond-invoice\"` discriminator and `Action::PayBondInvoice` survives JSON roundtrip.
- [x] New verify-rejection cases: missing id, wrong payload type, missing payload.
- [x] `Status::WaitingTakerBond` roundtrips through `Display` / `FromStr` / serde and serializes as `\"waiting-taker-bond\"`.
- [x] Existing `test_bond_resolution_rejected_on_non_admin_actions` extended to include `PayBondInvoice` so it cannot smuggle a `BondResolution` payload.

## After merge

Cut a minor release (`0.10.1` → `0.11.0`) so the downstream `mostro` Phase 1.5 PR can pin to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bond invoice payment processing capability with full validation and comprehensive error handling support to ensure consistent payment integrity and reliable transaction security across the platform
  * Introduced new "waiting for taker bond" order status to enable better order lifecycle management, improved state tracking, and enhanced visibility into bond-related requirements throughout transactions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mostro-core/pull/144)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->