### PR TITLE
feat(error): add CantDoReason::InvalidPayload

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -48,6 +48,11 @@ pub enum CantDoReason {
     InvalidPubkey,
     /// One or more request parameters are invalid.
     InvalidParameters,
+    /// The provided payload is the wrong shape for this action,
+    /// or carries values that cannot be processed (e.g. a
+    /// `BondResolution` requesting a slash against a side with no
+    /// active bond row). The caller should correct and resend.
+    InvalidPayload,
     /// The targeted order has already been canceled.
     OrderAlreadyCanceled,
     /// User creation failed on the server side.
@@ -227,5 +232,18 @@ impl std::fmt::Display for ServiceError {
             ServiceError::EncryptionError(e) => write!(f, "Encryption error: {}", e),
             ServiceError::DecryptionError(e) => write!(f, "Decryption error: {}", e),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_payload_serializes_to_snake_case() {
+        let json = serde_json::to_string(&CantDoReason::InvalidPayload).unwrap();
+        assert_eq!(json, "\"invalid_payload\"");
+        let round: CantDoReason = serde_json::from_str(&json).unwrap();
+        assert_eq!(round, CantDoReason::InvalidPayload);
     }
 }


### PR DESCRIPTION
Consumed by mostro's Phase 2 anti-abuse-bond admin handlers, per `docs/ANTI_ABUSE_BOND.md` §7.3 / §7.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved error handling for invalid or unprocessable request payloads, providing clearer feedback when payload structures are mismatched or cannot be processed as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mostro-core/pull/145)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->