### PR TITLE
feat(message): add BondInvoiceAccepted and BondPayoutCompleted actions

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -105,8 +105,20 @@ pub enum Action {
     CooperativeCancelAccepted,
     /// Mostro accepted the buyer's payout invoice.
     BuyerInvoiceAccepted,
+    /// Mostro accepted the winning counterparty's bond-payout invoice.
+    /// Bond dual of [`Action::BuyerInvoiceAccepted`] (Mostro → winner):
+    /// the payout bolt11 was received and the payment is now pending, so
+    /// the client can stop prompting the user for an invoice.
+    /// Payload: [`Payload::Order`] (amount = counterparty share).
+    BondInvoiceAccepted,
     /// Trade completed successfully.
     PurchaseCompleted,
+    /// Mostro paid out a slashed bond's counterparty share successfully.
+    /// Bond dual of [`Action::PurchaseCompleted`] (Mostro → winner): the
+    /// `send_payment` to the winner's bolt11 succeeded and the bond is
+    /// now settled, so the client can close the claim.
+    /// Payload: [`Payload::Order`] (amount = counterparty share).
+    BondPayoutCompleted,
     /// Mostro saw the hold-invoice payment accepted by the node.
     HoldInvoicePaymentAccepted,
     /// Mostro saw the hold-invoice payment settled.
@@ -715,12 +727,14 @@ impl MessageKind {
             | Action::DisputeInitiatedByPeer
             | Action::WaitingBuyerInvoice
             | Action::PurchaseCompleted
+            | Action::BondPayoutCompleted
             | Action::HoldInvoicePaymentAccepted
             | Action::HoldInvoicePaymentSettled
             | Action::HoldInvoicePaymentCanceled
             | Action::WaitingSellerToPay
             | Action::BuyerTookOrder
             | Action::BuyerInvoiceAccepted
+            | Action::BondInvoiceAccepted
             | Action::CooperativeCancelInitiatedByYou
             | Action::CooperativeCancelInitiatedByPeer
             | Action::CooperativeCancelAccepted
@@ -1038,7 +1052,9 @@ mod test {
             | Action::DisputeInitiatedByPeer
             | Action::CooperativeCancelAccepted
             | Action::BuyerInvoiceAccepted
+            | Action::BondInvoiceAccepted
             | Action::PurchaseCompleted
+            | Action::BondPayoutCompleted
             | Action::HoldInvoicePaymentAccepted
             | Action::HoldInvoicePaymentSettled
             | Action::HoldInvoicePaymentCanceled
@@ -1085,7 +1101,9 @@ mod test {
             Action::DisputeInitiatedByPeer,
             Action::CooperativeCancelAccepted,
             Action::BuyerInvoiceAccepted,
+            Action::BondInvoiceAccepted,
             Action::PurchaseCompleted,
+            Action::BondPayoutCompleted,
             Action::HoldInvoicePaymentAccepted,
             Action::HoldInvoicePaymentSettled,
             Action::HoldInvoicePaymentCanceled,
@@ -1124,6 +1142,103 @@ mod test {
                 !kind.verify(),
                 "BondPayoutRequest must be rejected on {action:?}"
             );
+        }
+    }
+
+    #[test]
+    fn test_bond_payout_ack_actions_verify_and_wire_format() {
+        use crate::message::BondResolution;
+
+        let order_id = uuid!("308e1272-d5f4-47e6-bd97-3504baea9c23");
+
+        // SmallOrder whose `amount` is the counterparty share carried by
+        // these Mostro → winner bond-payout acknowledgements.
+        let order = || SmallOrder {
+            id: Some(order_id),
+            kind: None,
+            status: None,
+            amount: 500,
+            fiat_code: "USD".to_string(),
+            min_amount: None,
+            max_amount: None,
+            fiat_amount: 0,
+            payment_method: "lightning".to_string(),
+            premium: 0,
+            buyer_trade_pubkey: None,
+            seller_trade_pubkey: None,
+            buyer_invoice: None,
+            created_at: None,
+            expires_at: None,
+        };
+
+        // Both variants are the bond duals of BuyerInvoiceAccepted /
+        // PurchaseCompleted: id required, Payload::Order accepted, and the
+        // bond request/resolution payloads rejected.
+        for (action, discriminator) in [
+            (Action::BondInvoiceAccepted, "bond-invoice-accepted"),
+            (Action::BondPayoutCompleted, "bond-payout-completed"),
+        ] {
+            // id set + Payload::Order verifies.
+            let ok = Message::Order(MessageKind::new(
+                Some(order_id),
+                Some(1),
+                Some(2),
+                action.clone(),
+                Some(Payload::Order(order())),
+            ));
+            assert!(ok.verify(), "{action:?} + Order should verify");
+
+            // Missing id is invalid.
+            let no_id = Message::Order(MessageKind::new(
+                None,
+                Some(1),
+                Some(2),
+                action.clone(),
+                Some(Payload::Order(order())),
+            ));
+            assert!(!no_id.verify(), "{action:?} without id must be rejected");
+
+            // BondResolution payload is rejected on these outbound acks.
+            let with_resolution = Message::Order(MessageKind::new(
+                Some(order_id),
+                Some(1),
+                Some(2),
+                action.clone(),
+                Some(Payload::BondResolution(BondResolution {
+                    slash_seller: true,
+                    slash_buyer: false,
+                })),
+            ));
+            assert!(
+                !with_resolution.verify(),
+                "{action:?} + BondResolution must be rejected"
+            );
+
+            // BondPayoutRequest payload is rejected too.
+            let with_request = Message::Order(MessageKind::new(
+                Some(order_id),
+                Some(1),
+                Some(2),
+                action.clone(),
+                Some(Payload::BondPayoutRequest(BondPayoutRequest {
+                    order: order(),
+                    slashed_at: 0,
+                })),
+            ));
+            assert!(
+                !with_request.verify(),
+                "{action:?} + BondPayoutRequest must be rejected"
+            );
+
+            // Wire format uses the kebab-case discriminator and round-trips.
+            let json = ok.as_json().unwrap();
+            assert!(
+                json.contains(&format!("\"action\":\"{discriminator}\"")),
+                "expected kebab-case discriminator {discriminator}, got: {json}"
+            );
+            let decoded = Message::from_json(&json).unwrap();
+            assert!(decoded.verify());
+            assert_eq!(decoded.inner_action(), Some(action));
         }
     }
 
@@ -1526,7 +1641,9 @@ mod test {
             Action::DisputeInitiatedByPeer,
             Action::CooperativeCancelAccepted,
             Action::BuyerInvoiceAccepted,
+            Action::BondInvoiceAccepted,
             Action::PurchaseCompleted,
+            Action::BondPayoutCompleted,
             Action::HoldInvoicePaymentAccepted,
             Action::HoldInvoicePaymentSettled,
             Action::HoldInvoicePaymentCanceled,


### PR DESCRIPTION
## Summary

Implements **Phase 3.5** of the anti-abuse bond feature on the `mostro-core` side: two new **outbound** (Mostro → winner) `Action` variants so the daemon can acknowledge a winning counterparty's bond payout. Spec: `mostro` repo `docs/ANTI_ABUSE_BOND.md` §8.5 and §14.3.

Both variants carry a `Payload::Order` (a `SmallOrder` whose `amount` is the counterparty share) and are the bond duals of the existing `BuyerInvoiceAccepted` / `PurchaseCompleted` actions:

- **`BondInvoiceAccepted`** (after `BuyerInvoiceAccepted`) — Mostro accepted the winner's bond-payout bolt11; payment is now pending.
- **`BondPayoutCompleted`** (after `PurchaseCompleted`) — the `send_payment` to the winner succeeded and the bond is now settled.

Both are added to the `MessageKind::verify` arm that requires `id.is_some()` and rejects `Payload::BondResolution` / `Payload::BondPayoutRequest`.

## Tests

- `verify()` true with `id` + `Some(Payload::Order(_))`; false without `id`; false with `BondResolution` / `BondPayoutRequest`.
- Kebab-case serde round-trip: `"bond-invoice-accepted"` / `"bond-payout-completed"`.
- Both variants added to the exhaustive action lists in the existing bond tests.

`cargo fmt`, `cargo clippy -D warnings`, `cargo build`, `cargo test` all green (58 unit + 4 doc tests).

## Notes

- Serde-additive, **non-breaking** (older clients ignore unknown variants); outbound-only, no new inbound handling or payload constructor.
- Version bump (`0.11.4`) and CHANGELOG are intentionally left out of this PR — they are handled by the release tooling (`cargo release` + git-cliff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced support for bond-related operations with new invoice acceptance and payout completion actions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mostro-core/pull/148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->