### PR TITLE
feat(message): add BondSlashed action

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -119,6 +119,14 @@ pub enum Action {
     /// now settled, so the client can close the claim.
     /// Payload: [`Payload::Order`] (amount = counterparty share).
     BondPayoutCompleted,
+    /// Mostro notifies a user that their anti-abuse bond was slashed for
+    /// letting a waiting-state timeout elapse (Mostro → slashed user). The
+    /// bond's hold invoice has been settled and the row moved to
+    /// `pending-payout`; the user keeps no claim over the forfeited sats.
+    /// Informational only — the slashed user receives this alongside the
+    /// `Action::Canceled` for the order itself.
+    /// Payload: [`Payload::Order`] (amount = slashed bond amount).
+    BondSlashed,
     /// Mostro saw the hold-invoice payment accepted by the node.
     HoldInvoicePaymentAccepted,
     /// Mostro saw the hold-invoice payment settled.
@@ -728,6 +736,7 @@ impl MessageKind {
             | Action::WaitingBuyerInvoice
             | Action::PurchaseCompleted
             | Action::BondPayoutCompleted
+            | Action::BondSlashed
             | Action::HoldInvoicePaymentAccepted
             | Action::HoldInvoicePaymentSettled
             | Action::HoldInvoicePaymentCanceled
@@ -1055,6 +1064,7 @@ mod test {
             | Action::BondInvoiceAccepted
             | Action::PurchaseCompleted
             | Action::BondPayoutCompleted
+            | Action::BondSlashed
             | Action::HoldInvoicePaymentAccepted
             | Action::HoldInvoicePaymentSettled
             | Action::HoldInvoicePaymentCanceled
@@ -1104,6 +1114,7 @@ mod test {
             Action::BondInvoiceAccepted,
             Action::PurchaseCompleted,
             Action::BondPayoutCompleted,
+            Action::BondSlashed,
             Action::HoldInvoicePaymentAccepted,
             Action::HoldInvoicePaymentSettled,
             Action::HoldInvoicePaymentCanceled,
@@ -1171,12 +1182,15 @@ mod test {
             expires_at: None,
         };
 
-        // Both variants are the bond duals of BuyerInvoiceAccepted /
-        // PurchaseCompleted: id required, Payload::Order accepted, and the
-        // bond request/resolution payloads rejected.
+        // These bond notifications carry Payload::Order (BondInvoiceAccepted
+        // / BondPayoutCompleted are the duals of BuyerInvoiceAccepted /
+        // PurchaseCompleted; BondSlashed informs the slashed user): id
+        // required, Payload::Order accepted, and the bond request/resolution
+        // payloads rejected.
         for (action, discriminator) in [
             (Action::BondInvoiceAccepted, "bond-invoice-accepted"),
             (Action::BondPayoutCompleted, "bond-payout-completed"),
+            (Action::BondSlashed, "bond-slashed"),
         ] {
             // id set + Payload::Order verifies.
             let ok = Message::Order(MessageKind::new(
@@ -1644,6 +1658,7 @@ mod test {
             Action::BondInvoiceAccepted,
             Action::PurchaseCompleted,
             Action::BondPayoutCompleted,
+            Action::BondSlashed,
             Action::HoldInvoicePaymentAccepted,
             Action::HoldInvoicePaymentSettled,
             Action::HoldInvoicePaymentCanceled,

--- a/src/nip59.rs
+++ b/src/nip59.rs
@@ -330,6 +330,7 @@ fn action_accepts_missing_request_id(action: &Action) -> bool {
             | Action::Rate
             | Action::RateReceived
             | Action::SendDm
+            | Action::BondSlashed
     )
 }
 


### PR DESCRIPTION
## Summary

Adds a new `BondSlashed` action so Mostro can notify a user that their anti-abuse bond was slashed after letting a waiting-state timeout elapse.

- The bond's hold invoice is settled and the row moved to `pending-payout`; the slashed user keeps no claim over the forfeited sats.
- Informational only — the slashed user receives this alongside `Action::Canceled` for the order itself.

## Behavior

- Carries `Payload::Order` (amount = slashed bond amount).
- Requires an `id`.
- Accepts a missing request id (notification-style, like `Rate`/`SendDm`).
- Rejects the bond request/resolution payloads.

## Testing

- `cargo fmt`
- `cargo test` — 58 unit + 4 doc tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced bond slashing action support to the protocol, enabling proper handling of related protocol messages.

* **Improvements**
  * Updated message verification logic to correctly process the new action and support unsolicited message handling.

* **Tests**
  * Extended test coverage to validate the new action type across various scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mostro-core/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->