### PR TITLE
feat(cashu): protocol types for 2-of-3 multisig escrow (F1)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -85,6 +85,21 @@ pub enum CantDoReason {
     InvalidFiatCurrency,
     /// The caller is being rate-limited.
     TooManyRequests,
+    /// The submitted Cashu token is malformed, cannot be parsed, or its
+    /// 2-of-3 spending condition does not match the expected
+    /// buyer/seller/Mostro pubkeys.
+    InvalidCashuToken,
+    /// The configured Cashu mint could not be reached or did not answer the
+    /// state check.
+    CashuMintUnavailable,
+    /// The provided mint URL is malformed or does not match the node's
+    /// configured mint.
+    InvalidMintUrl,
+    /// The requested action needs a locked Cashu escrow, but none has been
+    /// recorded for this order.
+    CashuEscrowNotLocked,
+    /// A required Cashu signature is missing from the request.
+    CashuSignatureMissing,
 }
 
 /// Internal errors raised by services behind the Mostro API.

--- a/src/message.rs
+++ b/src/message.rs
@@ -200,11 +200,11 @@ pub enum Action {
     /// mint) and the trade can proceed. Informational; the daemon never
     /// takes custody. Direction: Mostro → buyer/seller.
     CashuEscrowLocked,
-    /// Mostro hands its `P_M` signature to the dispute winner so they can
-    /// assemble a valid 2-of-3 swap at the mint. Emitted only during
-    /// dispute resolution, as the Cashu counterpart of
+    /// Mostro hands its `P_M` signatures (one per escrowed proof) to the
+    /// dispute winner so they can assemble a valid 2-of-3 swap at the mint.
+    /// Emitted only during dispute resolution, as the Cashu counterpart of
     /// [`Action::AdminSettled`] / [`Action::AdminCanceled`].
-    /// Direction: Mostro → winner. Payload: [`Payload::CashuSignature`].
+    /// Direction: Mostro → winner. Payload: [`Payload::CashuSignatures`].
     CashuPmSignature,
 }
 
@@ -633,6 +633,32 @@ impl CashuLockProof {
     }
 }
 
+/// Mostro's `P_M` signature for a single escrowed proof.
+///
+/// Under NUT-11 SIG_INPUTS each input proof carries its own witness with a
+/// signature over that proof's own secret, so a Cashu token split across
+/// several denominations needs one signature per proof. The dispute winner
+/// matches each signature to its proof by `secret` when populating the
+/// per-proof witnesses and assembling the mint swap. See
+/// [`Payload::CashuSignatures`].
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+pub struct CashuProofSignature {
+    /// NUT-11 secret of the proof this signature applies to, exactly as it
+    /// appears in the escrowed token. Used to match the signature to its
+    /// proof.
+    pub secret: String,
+    /// Mostro's `P_M` signature (hex) over `secret`, to be inserted into that
+    /// proof's NUT-11 witness.
+    pub signature: String,
+}
+
+impl CashuProofSignature {
+    /// Create a new [`CashuProofSignature`].
+    pub fn new(secret: String, signature: String) -> Self {
+        Self { secret, signature }
+    }
+}
+
 /// Typed payload attached to a [`MessageKind`].
 ///
 /// Each variant corresponds to a set of [`Action`] values that can legally
@@ -687,10 +713,12 @@ pub enum Payload {
     /// Cashu 2-of-3 multisig escrow lock submitted on
     /// [`Action::AddCashuEscrow`] (seller → Mostro). See [`CashuLockProof`].
     CashuLockProof(CashuLockProof),
-    /// A NUT-11 P2PK signature (hex) over the escrowed proofs. Carried by
-    /// [`Action::CashuPmSignature`] when Mostro delivers its `P_M` signature
-    /// to a dispute winner.
-    CashuSignature(String),
+    /// Mostro's NUT-11 P2PK signatures over the escrowed proofs, one entry
+    /// per proof. Carried by [`Action::CashuPmSignature`] when Mostro delivers
+    /// its `P_M` signatures to a dispute winner. A token split across several
+    /// denominations contains multiple proofs, and SIG_INPUTS requires each to
+    /// be signed independently. See [`CashuProofSignature`].
+    CashuSignatures(Vec<CashuProofSignature>),
 }
 
 #[allow(dead_code)]
@@ -804,7 +832,7 @@ impl MessageKind {
                 if self.id.is_none() {
                     return false;
                 }
-                matches!(&self.payload, Some(Payload::CashuSignature(_)))
+                matches!(&self.payload, Some(Payload::CashuSignatures(sigs)) if !sigs.is_empty())
             }
             Action::TakeSell
             | Action::TakeBuy
@@ -947,7 +975,8 @@ impl MessageKind {
 #[cfg(test)]
 mod test {
     use crate::message::{
-        Action, BondPayoutRequest, CashuLockProof, Message, MessageKind, Payload, Peer,
+        Action, BondPayoutRequest, CashuLockProof, CashuProofSignature, Message, MessageKind,
+        Payload, Peer,
     };
     use crate::order::SmallOrder;
     use crate::user::UserInfo;
@@ -2124,22 +2153,25 @@ mod test {
     }
 
     #[test]
-    fn test_cashu_pm_signature_verifies_with_signature() {
+    fn test_cashu_pm_signature_verifies_with_signatures() {
         let order_id = uuid!("308e1272-d5f4-47e6-bd97-3504baea9c23");
         let kind = MessageKind::new(
             Some(order_id),
             None,
             None,
             Action::CashuPmSignature,
-            Some(Payload::CashuSignature("deadbeef".to_string())),
+            Some(Payload::CashuSignatures(vec![
+                CashuProofSignature::new("secret-0".to_string(), "deadbeef".to_string()),
+                CashuProofSignature::new("secret-1".to_string(), "c0ffee".to_string()),
+            ])),
         );
         assert!(
             kind.verify(),
-            "CashuSignature must verify on CashuPmSignature"
+            "CashuSignatures must verify on CashuPmSignature"
         );
 
         let json = Message::Order(kind).as_json().unwrap();
-        assert!(json.contains("cashu_signature"));
+        assert!(json.contains("cashu_signatures"));
         assert!(Message::from_json(&json).unwrap().verify());
 
         // Wrong payload ⇒ invalid.
@@ -2147,6 +2179,20 @@ mod test {
         assert!(
             !wrong.verify(),
             "CashuPmSignature without a signature payload must be rejected"
+        );
+
+        // Empty signature set ⇒ invalid: a multi-proof escrow needs one
+        // signature per proof, so an empty collection cannot assemble a swap.
+        let empty = MessageKind::new(
+            Some(order_id),
+            None,
+            None,
+            Action::CashuPmSignature,
+            Some(Payload::CashuSignatures(vec![])),
+        );
+        assert!(
+            !empty.verify(),
+            "CashuPmSignature with an empty signature set must be rejected"
         );
     }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -190,6 +190,22 @@ pub enum Action {
     /// Listing of orders in response to a query.
     /// Payload: [`Payload::Ids`] or [`Payload::Orders`].
     Orders,
+    /// Seller submits a Cashu 2-of-3 multisig locked token as the trade
+    /// escrow, in place of paying a Lightning hold invoice (Cashu escrow
+    /// mode). Direction: seller → Mostro.
+    /// Payload: [`Payload::CashuLockProof`].
+    AddCashuEscrow,
+    /// Mostro confirms it validated the seller's Cashu escrow token (the
+    /// 2-of-3 condition is well-formed and the proofs are unspent at the
+    /// mint) and the trade can proceed. Informational; the daemon never
+    /// takes custody. Direction: Mostro → buyer/seller.
+    CashuEscrowLocked,
+    /// Mostro hands its `P_M` signature to the dispute winner so they can
+    /// assemble a valid 2-of-3 swap at the mint. Emitted only during
+    /// dispute resolution, as the Cashu counterpart of
+    /// [`Action::AdminSettled`] / [`Action::AdminCanceled`].
+    /// Direction: Mostro → winner. Payload: [`Payload::CashuSignature`].
+    CashuPmSignature,
 }
 
 impl fmt::Display for Action {
@@ -564,6 +580,59 @@ pub struct BondPayoutRequest {
     pub slashed_at: i64,
 }
 
+/// Cashu 2-of-3 multisig escrow lock submitted by the seller.
+///
+/// Carried inside [`Payload::CashuLockProof`] on [`Action::AddCashuEscrow`]
+/// (seller → Mostro). It describes a NUT-11 P2PK token locked to a 2-of-3
+/// spending condition over the buyer (`P_B`), seller (`P_S`) and Mostro
+/// (`P_M`) pubkeys. Mostro validates the condition and confirms the proofs
+/// are unspent at the mint (NUT-07 `checkstate`) without ever taking
+/// custody — it only ever holds one of the three keys.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+pub struct CashuLockProof {
+    /// Serialized Cashu token (the locked ecash) as submitted by the seller.
+    pub token: String,
+    /// URL of the mint hosting the escrowed proofs. Must match the node's
+    /// configured mint.
+    pub mint_url: String,
+    /// Buyer pubkey embedded in the 2-of-3 condition (`P_B`), hex.
+    pub buyer_pubkey: String,
+    /// Seller pubkey embedded in the 2-of-3 condition (`P_S`), hex.
+    pub seller_pubkey: String,
+    /// Mostro/arbitrator pubkey embedded in the 2-of-3 condition (`P_M`),
+    /// hex.
+    pub mostro_pubkey: String,
+}
+
+impl CashuLockProof {
+    /// Create a new [`CashuLockProof`].
+    pub fn new(
+        token: String,
+        mint_url: String,
+        buyer_pubkey: String,
+        seller_pubkey: String,
+        mostro_pubkey: String,
+    ) -> Self {
+        Self {
+            token,
+            mint_url,
+            buyer_pubkey,
+            seller_pubkey,
+            mostro_pubkey,
+        }
+    }
+
+    /// Parse a [`CashuLockProof`] from its JSON representation.
+    pub fn from_json(json: &str) -> Result<Self, ServiceError> {
+        serde_json::from_str(json).map_err(|_| ServiceError::MessageSerializationError)
+    }
+
+    /// Serialize the lock proof to a JSON string.
+    pub fn as_json(&self) -> Result<String, ServiceError> {
+        serde_json::to_string(&self).map_err(|_| ServiceError::MessageSerializationError)
+    }
+}
+
 /// Typed payload attached to a [`MessageKind`].
 ///
 /// Each variant corresponds to a set of [`Action`] values that can legally
@@ -615,6 +684,13 @@ pub enum Payload {
     /// [`Payload::PaymentRequest`] with the actual bolt11. See
     /// [`BondPayoutRequest`].
     BondPayoutRequest(BondPayoutRequest),
+    /// Cashu 2-of-3 multisig escrow lock submitted on
+    /// [`Action::AddCashuEscrow`] (seller → Mostro). See [`CashuLockProof`].
+    CashuLockProof(CashuLockProof),
+    /// A NUT-11 P2PK signature (hex) over the escrowed proofs. Carried by
+    /// [`Action::CashuPmSignature`] when Mostro delivers its `P_M` signature
+    /// to a dispute winner.
+    CashuSignature(String),
 }
 
 #[allow(dead_code)]
@@ -718,6 +794,18 @@ impl MessageKind {
                 }
                 matches!(&self.payload, None | Some(Payload::BondResolution(_)))
             }
+            Action::AddCashuEscrow => {
+                if self.id.is_none() {
+                    return false;
+                }
+                matches!(&self.payload, Some(Payload::CashuLockProof(_)))
+            }
+            Action::CashuPmSignature => {
+                if self.id.is_none() {
+                    return false;
+                }
+                matches!(&self.payload, Some(Payload::CashuSignature(_)))
+            }
             Action::TakeSell
             | Action::TakeBuy
             | Action::FiatSent
@@ -752,6 +840,7 @@ impl MessageKind {
             | Action::AdminAddSolver
             | Action::SendDm
             | Action::TradePubkey
+            | Action::CashuEscrowLocked
             | Action::Canceled => {
                 if self.id.is_none() {
                     return false;
@@ -857,7 +946,9 @@ impl MessageKind {
 
 #[cfg(test)]
 mod test {
-    use crate::message::{Action, BondPayoutRequest, Message, MessageKind, Payload, Peer};
+    use crate::message::{
+        Action, BondPayoutRequest, CashuLockProof, Message, MessageKind, Payload, Peer,
+    };
     use crate::order::SmallOrder;
     use crate::user::UserInfo;
     use nostr_sdk::Keys;
@@ -1090,6 +1181,9 @@ mod test {
             | Action::TradePubkey
             | Action::RestoreSession
             | Action::LastTradeIndex
+            | Action::AddCashuEscrow
+            | Action::CashuEscrowLocked
+            | Action::CashuPmSignature
             | Action::Orders => {}
         };
 
@@ -1141,6 +1235,9 @@ mod test {
             Action::RestoreSession,
             Action::LastTradeIndex,
             Action::Orders,
+            Action::AddCashuEscrow,
+            Action::CashuEscrowLocked,
+            Action::CashuPmSignature,
         ];
 
         for action in other_actions {
@@ -1951,6 +2048,121 @@ mod test {
         assert_eq!(
             deserialized_seller.solver_pubkey,
             helper_seller_dispute.solver_pubkey
+        );
+    }
+
+    fn sample_lock_proof() -> CashuLockProof {
+        CashuLockProof::new(
+            "cashuAeyJ0b2tlbiI6dGVzdA".to_string(),
+            "https://mint.example".to_string(),
+            "02b_buyer".to_string(),
+            "02s_seller".to_string(),
+            "02m_mostro".to_string(),
+        )
+    }
+
+    #[test]
+    fn test_cashu_lock_proof_json_round_trip() {
+        let proof = sample_lock_proof();
+        let json = proof.as_json().unwrap();
+        let back = CashuLockProof::from_json(&json).unwrap();
+        assert_eq!(back, proof);
+    }
+
+    #[test]
+    fn test_add_cashu_escrow_verifies_with_lock_proof() {
+        let order_id = uuid!("308e1272-d5f4-47e6-bd97-3504baea9c23");
+        let payload = Payload::CashuLockProof(sample_lock_proof());
+        let kind = MessageKind::new(
+            Some(order_id),
+            None,
+            None,
+            Action::AddCashuEscrow,
+            Some(payload),
+        );
+        assert!(
+            kind.verify(),
+            "CashuLockProof must verify on AddCashuEscrow"
+        );
+
+        // Round-trip through JSON to catch a serde-rename mismatch on the
+        // new snake_case discriminator.
+        let json = Message::Order(kind).as_json().unwrap();
+        assert!(json.contains("cashu_lock_proof"));
+        assert!(Message::from_json(&json).unwrap().verify());
+    }
+
+    #[test]
+    fn test_add_cashu_escrow_requires_id_and_right_payload() {
+        let order_id = uuid!("308e1272-d5f4-47e6-bd97-3504baea9c23");
+
+        // Missing id ⇒ invalid.
+        let no_id = MessageKind::new(
+            None,
+            None,
+            None,
+            Action::AddCashuEscrow,
+            Some(Payload::CashuLockProof(sample_lock_proof())),
+        );
+        assert!(
+            !no_id.verify(),
+            "AddCashuEscrow without id must be rejected"
+        );
+
+        // Wrong payload ⇒ invalid.
+        let wrong_payload = MessageKind::new(
+            Some(order_id),
+            None,
+            None,
+            Action::AddCashuEscrow,
+            Some(Payload::TextMessage("not a lock proof".to_string())),
+        );
+        assert!(
+            !wrong_payload.verify(),
+            "AddCashuEscrow with non-lock-proof payload must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_cashu_pm_signature_verifies_with_signature() {
+        let order_id = uuid!("308e1272-d5f4-47e6-bd97-3504baea9c23");
+        let kind = MessageKind::new(
+            Some(order_id),
+            None,
+            None,
+            Action::CashuPmSignature,
+            Some(Payload::CashuSignature("deadbeef".to_string())),
+        );
+        assert!(
+            kind.verify(),
+            "CashuSignature must verify on CashuPmSignature"
+        );
+
+        let json = Message::Order(kind).as_json().unwrap();
+        assert!(json.contains("cashu_signature"));
+        assert!(Message::from_json(&json).unwrap().verify());
+
+        // Wrong payload ⇒ invalid.
+        let wrong = MessageKind::new(Some(order_id), None, None, Action::CashuPmSignature, None);
+        assert!(
+            !wrong.verify(),
+            "CashuPmSignature without a signature payload must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_cashu_escrow_locked_is_informational() {
+        let order_id = uuid!("308e1272-d5f4-47e6-bd97-3504baea9c23");
+
+        // Informational ack with an id and no payload verifies.
+        let ok = MessageKind::new(Some(order_id), None, None, Action::CashuEscrowLocked, None);
+        assert!(ok.verify(), "CashuEscrowLocked with id must verify");
+
+        // Missing id ⇒ invalid.
+        let no_id = MessageKind::new(None, None, None, Action::CashuEscrowLocked, None);
+        assert!(
+            !no_id.verify(),
+            "CashuEscrowLocked without id must be rejected"
         );
     }
 }

--- a/src/nip59.rs
+++ b/src/nip59.rs
@@ -331,6 +331,8 @@ fn action_accepts_missing_request_id(action: &Action) -> bool {
             | Action::RateReceived
             | Action::SendDm
             | Action::BondSlashed
+            | Action::CashuEscrowLocked
+            | Action::CashuPmSignature
     )
 }
 
@@ -661,5 +663,21 @@ mod tests {
     fn validate_response_with_no_expected_id_is_ok() {
         let msg = sample_order_message(None);
         validate_response(&msg, None).unwrap();
+    }
+
+    #[test]
+    fn validate_response_allows_cashu_server_events_without_request_id() {
+        // Both Cashu notifications are server-originated and may arrive while
+        // the client is still waiting on an earlier request_id.
+        for action in [Action::CashuEscrowLocked, Action::CashuPmSignature] {
+            let msg = Message::Order(MessageKind::new(
+                Some(uuid!("308e1272-d5f4-47e6-bd97-3504baea9c23")),
+                None,
+                None,
+                action,
+                None,
+            ));
+            validate_response(&msg, Some(1)).unwrap();
+        }
     }
 }

--- a/src/order.rs
+++ b/src/order.rs
@@ -248,6 +248,15 @@ pub struct Order {
     pub next_trade_pubkey: Option<String>,
     /// Trade index announced by a range-order maker for the next trade.
     pub next_trade_index: Option<i64>,
+    /// URL of the Cashu mint hosting the escrow (Cashu escrow mode only).
+    /// `None` for Lightning orders.
+    pub cashu_mint_url: Option<String>,
+    /// Serialized Cashu 2-of-3 multisig token held as escrow (Cashu escrow
+    /// mode only). `None` for Lightning orders.
+    pub cashu_escrow_token: Option<String>,
+    /// Unix timestamp (seconds) when the Cashu escrow token was validated
+    /// and locked in. `None` until the escrow is locked.
+    pub cashu_escrow_locked_at: Option<i64>,
 }
 
 impl From<SmallOrder> for Order {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -17,9 +17,9 @@ pub use crate::chat::{
 pub use crate::dispute::{Dispute, SolverDisputeInfo, Status as DisputeStatus};
 pub use crate::error::{CantDoReason, MostroError, ServiceError};
 pub use crate::message::{
-    Action, BondPayoutRequest, BondResolution, CashuLockProof, Message, MessageKind, Payload,
-    PaymentFailedInfo, Peer, RestoreSessionInfo, RestoredDisputeHelper, RestoredDisputesInfo,
-    RestoredOrderHelper, RestoredOrdersInfo,
+    Action, BondPayoutRequest, BondResolution, CashuLockProof, CashuProofSignature, Message,
+    MessageKind, Payload, PaymentFailedInfo, Peer, RestoreSessionInfo, RestoredDisputeHelper,
+    RestoredDisputesInfo, RestoredOrderHelper, RestoredOrdersInfo,
 };
 pub use crate::nip59::{
     unwrap_message, validate_response, wrap_message, UnwrappedMessage, WrapOptions,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -17,9 +17,9 @@ pub use crate::chat::{
 pub use crate::dispute::{Dispute, SolverDisputeInfo, Status as DisputeStatus};
 pub use crate::error::{CantDoReason, MostroError, ServiceError};
 pub use crate::message::{
-    Action, BondPayoutRequest, BondResolution, Message, MessageKind, Payload, PaymentFailedInfo,
-    Peer, RestoreSessionInfo, RestoredDisputeHelper, RestoredDisputesInfo, RestoredOrderHelper,
-    RestoredOrdersInfo,
+    Action, BondPayoutRequest, BondResolution, CashuLockProof, Message, MessageKind, Payload,
+    PaymentFailedInfo, Peer, RestoreSessionInfo, RestoredDisputeHelper, RestoredDisputesInfo,
+    RestoredOrderHelper, RestoredOrdersInfo,
 };
 pub use crate::nip59::{
     unwrap_message, validate_response, wrap_message, UnwrappedMessage, WrapOptions,


### PR DESCRIPTION
## What

Foundation milestone **F1** of the Cashu 2-of-3 multisig escrow rollout (see [`docs/CASHU_ESCROW_ARCHITECTURE.md`](https://github.com/MostroP2P/mostro/blob/main/docs/CASHU_ESCROW_ARCHITECTURE.md) in the mostro repo, PR #756). This is the shared protocol contract the daemon and clients compile against. It is **purely additive** and has no behavior on its own — it unblocks the parallel daemon-side workstreams.

## Why first

The daemon can't reference `Action::AddCashuEscrow` / the new payloads until they exist here. Freezing this protocol surface lets several developers build the daemon tracks (lock / release / cancel / dispute) in parallel against a stable contract.

## Changes

**`message.rs`**
- `Action`: `AddCashuEscrow` (seller submits the 2-of-3 locked token → Mostro), `CashuEscrowLocked` (Mostro acks a validated escrow → parties), `CashuPmSignature` (Mostro hands its `P_M` signature to a dispute winner).
- `Payload`: `CashuLockProof(CashuLockProof)`, `CashuSignature(String)`.
- New `CashuLockProof` struct `{ token, mint_url, buyer_pubkey, seller_pubkey, mostro_pubkey }` with JSON helpers.
- `verify()`: `AddCashuEscrow` requires id + `CashuLockProof`; `CashuPmSignature` requires id + `CashuSignature`; `CashuEscrowLocked` is an informational ack (id required). Exhaustiveness guard updated.

**`error.rs`** — `CantDoReason`: `InvalidCashuToken`, `CashuMintUnavailable`, `InvalidMintUrl`, `CashuEscrowNotLocked`, `CashuSignatureMissing`.

**`order.rs`** — `Order` fields `cashu_mint_url`, `cashu_escrow_token`, `cashu_escrow_locked_at` (all `Option`, `None` for Lightning orders).

> **Note:** no version bump in this PR — the crate version stays at `0.11.5` and will be bumped in a separate `cargo release`.

## Design notes

- **Release & cooperative-cancel need no new Action.** The seller↔buyer signature rides the existing P2P chat channel (free-text `ChatMessage.content`). Only the dispute case needs a Mostro→user action (`CashuPmSignature`), since that delivery goes through the normal message envelope.
- **`CashuLockProof` carries no signatures** — it's just the locked token + the three pubkeys + mint. Signatures are exchanged separately via `CashuSignature`.

## Coordination

The new `Order` fields require the daemon-side migration (Foundation **F5**) to land **before** the mostro daemon adopts this crate — otherwise sqlx `FromRow` fails on the missing columns.

## Testing

- Default (wasm) and `--features sqlx` builds clean; clippy clean on both.
- `cargo fmt --check` passes.
- 63 unit tests pass, including 5 new ones: `CashuLockProof` JSON round-trip, `AddCashuEscrow` verify (happy + missing-id + wrong-payload), `CashuPmSignature` verify, `CashuEscrowLocked` informational.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cashu escrow support, including order fields for mint URLs and locked tokens.
  * Introduced new messaging actions for escrow submission and signature delivery.
  * Added five new error types for Cashu token validation and mint connectivity issues.

* **Tests**
  * Extended test coverage for Cashu escrow payload validation and protocol verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mostro-core/pull/150?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->