### PR TITLE
feat(order): add WaitingMakerBond status

### DIFF
--- a/src/order.rs
+++ b/src/order.rs
@@ -92,16 +92,20 @@ pub enum Status {
     /// from [`Status::Pending`] (advertised, no taker yet) and from
     /// [`Status::WaitingPayment`] (trade escrow expected from the seller).
     WaitingTakerBond,
+    /// Both parties agreed to cooperatively cancel the trade.
+    CooperativelyCanceled,
+    /// Order has been taken and the trade is in progress.
+    InProgress,
     /// Order has been created by the maker but Mostro is awaiting the
     /// maker's anti-abuse bond hold-invoice payment before publishing the
     /// order to Nostr. Distinct from [`Status::Pending`] (already published
     /// and advertised): an order in this status has **no** NIP-33 event yet
     /// and is invisible in the order book until the bond locks.
+    ///
+    /// Appended at the end of the enum on purpose: `Status` is exported via
+    /// `#[wasm_bindgen]` as a C-like enum, so variant order is the Wasm ABI.
+    /// Inserting earlier would renumber later variants for JS consumers.
     WaitingMakerBond,
-    /// Both parties agreed to cooperatively cancel the trade.
-    CooperativelyCanceled,
-    /// Order has been taken and the trade is in progress.
-    InProgress,
 }
 
 impl Display for Status {

--- a/src/order.rs
+++ b/src/order.rs
@@ -92,6 +92,12 @@ pub enum Status {
     /// from [`Status::Pending`] (advertised, no taker yet) and from
     /// [`Status::WaitingPayment`] (trade escrow expected from the seller).
     WaitingTakerBond,
+    /// Order has been created by the maker but Mostro is awaiting the
+    /// maker's anti-abuse bond hold-invoice payment before publishing the
+    /// order to Nostr. Distinct from [`Status::Pending`] (already published
+    /// and advertised): an order in this status has **no** NIP-33 event yet
+    /// and is invisible in the order book until the bond locks.
+    WaitingMakerBond,
     /// Both parties agreed to cooperatively cancel the trade.
     CooperativelyCanceled,
     /// Order has been taken and the trade is in progress.
@@ -115,6 +121,7 @@ impl Display for Status {
             Status::WaitingBuyerInvoice => write!(f, "waiting-buyer-invoice"),
             Status::WaitingPayment => write!(f, "waiting-payment"),
             Status::WaitingTakerBond => write!(f, "waiting-taker-bond"),
+            Status::WaitingMakerBond => write!(f, "waiting-maker-bond"),
             Status::CooperativelyCanceled => write!(f, "cooperatively-canceled"),
             Status::InProgress => write!(f, "in-progress"),
         }
@@ -140,6 +147,7 @@ impl FromStr for Status {
             "waiting-buyer-invoice" => std::result::Result::Ok(Self::WaitingBuyerInvoice),
             "waiting-payment" => std::result::Result::Ok(Self::WaitingPayment),
             "waiting-taker-bond" => std::result::Result::Ok(Self::WaitingTakerBond),
+            "waiting-maker-bond" => std::result::Result::Ok(Self::WaitingMakerBond),
             "cooperatively-canceled" => std::result::Result::Ok(Self::CooperativelyCanceled),
             "in-progress" => std::result::Result::Ok(Self::InProgress),
             _ => Err(()),
@@ -788,6 +796,20 @@ mod tests {
         assert_eq!(json, "\"waiting-taker-bond\"");
         let back: Status = serde_json::from_str(&json).unwrap();
         assert_eq!(back, Status::WaitingTakerBond);
+    }
+
+    #[test]
+    fn test_status_waiting_maker_bond_roundtrip() {
+        assert_eq!(Status::WaitingMakerBond.to_string(), "waiting-maker-bond");
+        assert_eq!(
+            Status::from_str("waiting-maker-bond").unwrap(),
+            Status::WaitingMakerBond
+        );
+        // serde representation must match the string form.
+        let json = serde_json::to_string(&Status::WaitingMakerBond).unwrap();
+        assert_eq!(json, "\"waiting-maker-bond\"");
+        let back: Status = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, Status::WaitingMakerBond);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a new `Status::WaitingMakerBond` order status for orders created by the maker but awaiting the anti-abuse bond hold-invoice payment before being published to Nostr.

An order in this status:
- Has **no** NIP-33 event yet
- Is invisible in the order book until the bond locks
- Is distinct from `Status::Pending` (already published and advertised)

## Changes

- New `Status::WaitingMakerBond` variant with doc comment
- `Display` impl → `"waiting-maker-bond"`
- `FromStr` impl ← `"waiting-maker-bond"`
- Roundtrip test covering `Display`/`FromStr`/serde representation

## Testing

- `cargo fmt`
- `cargo test test_status_waiting_maker_bond_roundtrip` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "Waiting for Maker Bond" status to the order system, expanding the order lifecycle to improve tracking and visibility of orders at this specific workflow stage.

* **Tests**
  * Added unit tests to verify the new status variant properly handles serialization, deserialization, and string parsing across all supported data formats and representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->