### PR TITLE
chore: drop sqlx-crud from mostro-core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,9 +51,6 @@ sqlx = { version = "0.6.2", features = [
   "chrono",
   "uuid",
 ], optional = true }
-sqlx-crud = { version = "0.4.0", features = [
-  "runtime-tokio-rustls",
-], optional = true }
 wasm-bindgen = { version = "0.2.92", optional = true }
 nostr-sdk = { version = "0.44.1", features = ["nip44", "nip59"] }
 bitcoin = "0.32.7"
@@ -61,7 +58,7 @@ bitcoin = "0.32.7"
 [features]
 default = ["wasm"]
 wasm = ["dep:wasm-bindgen"]
-sqlx = ["dep:wasm-bindgen", "dep:sqlx", "dep:sqlx-crud"]
+sqlx = ["dep:wasm-bindgen", "dep:sqlx"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/src/db/order.rs
+++ b/src/db/order.rs
@@ -5,8 +5,9 @@ use sqlx::{query_builder::Separated, Pool, QueryBuilder, Sqlite};
 use crate::db::Crud;
 use crate::order::Order;
 
-/// Persisted `orders` columns, in [`Order`] field order. Keep in sync with
-/// `mostrod` migrations and [`Order`]'s `FromRow` mapping.
+/// Persisted `orders` INSERT column names, in bind order. Keep in sync with
+/// [`push_order_insert_binds`], `mostrod` migrations, and [`Order`]'s
+/// `FromRow` mapping. Drift is caught by the roundtrip integration tests.
 const ORDER_INSERT_COLUMNS: &[&str] = &[
     "id",
     "kind",
@@ -56,105 +57,139 @@ const ORDER_INSERT_COLUMNS: &[&str] = &[
     "cashu_escrow_locked_at",
 ];
 
-fn order_update_columns() -> &'static [&'static str] {
-    &ORDER_INSERT_COLUMNS[1..]
-}
-
-#[derive(Copy, Clone)]
-enum BindStyle {
-    Insert,
-    Update,
-}
-
-fn bind_order_column<'a>(
-    sep: &mut Separated<'_, 'a, Sqlite, &'static str>,
-    column: &str,
-    order: &'a Order,
-    style: BindStyle,
-) {
-    if matches!(style, BindStyle::Update) {
-        sep.push(column);
-        sep.push_unseparated(" = ");
-    }
-
-    match column {
-        "id" => bind_column_value(sep, order.id, style),
-        "kind" => bind_column_value(sep, &order.kind, style),
-        "event_id" => bind_column_value(sep, &order.event_id, style),
-        "hash" => bind_column_value(sep, &order.hash, style),
-        "preimage" => bind_column_value(sep, &order.preimage, style),
-        "creator_pubkey" => bind_column_value(sep, &order.creator_pubkey, style),
-        "cancel_initiator_pubkey" => bind_column_value(sep, &order.cancel_initiator_pubkey, style),
-        "buyer_pubkey" => bind_column_value(sep, &order.buyer_pubkey, style),
-        "master_buyer_pubkey" => bind_column_value(sep, &order.master_buyer_pubkey, style),
-        "seller_pubkey" => bind_column_value(sep, &order.seller_pubkey, style),
-        "master_seller_pubkey" => bind_column_value(sep, &order.master_seller_pubkey, style),
-        "status" => bind_column_value(sep, &order.status, style),
-        "price_from_api" => bind_column_value(sep, order.price_from_api, style),
-        "premium" => bind_column_value(sep, order.premium, style),
-        "payment_method" => bind_column_value(sep, &order.payment_method, style),
-        "amount" => bind_column_value(sep, order.amount, style),
-        "min_amount" => bind_column_value(sep, order.min_amount, style),
-        "max_amount" => bind_column_value(sep, order.max_amount, style),
-        "buyer_dispute" => bind_column_value(sep, order.buyer_dispute, style),
-        "seller_dispute" => bind_column_value(sep, order.seller_dispute, style),
-        "buyer_cooperativecancel" => bind_column_value(sep, order.buyer_cooperativecancel, style),
-        "seller_cooperativecancel" => bind_column_value(sep, order.seller_cooperativecancel, style),
-        "fee" => bind_column_value(sep, order.fee, style),
-        "routing_fee" => bind_column_value(sep, order.routing_fee, style),
-        "dev_fee" => bind_column_value(sep, order.dev_fee, style),
-        "dev_fee_paid" => bind_column_value(sep, order.dev_fee_paid, style),
-        "dev_fee_payment_hash" => bind_column_value(sep, &order.dev_fee_payment_hash, style),
-        "fiat_code" => bind_column_value(sep, &order.fiat_code, style),
-        "fiat_amount" => bind_column_value(sep, order.fiat_amount, style),
-        "buyer_invoice" => bind_column_value(sep, &order.buyer_invoice, style),
-        "range_parent_id" => bind_column_value(sep, order.range_parent_id, style),
-        "invoice_held_at" => bind_column_value(sep, order.invoice_held_at, style),
-        "taken_at" => bind_column_value(sep, order.taken_at, style),
-        "created_at" => bind_column_value(sep, order.created_at, style),
-        "buyer_sent_rate" => bind_column_value(sep, order.buyer_sent_rate, style),
-        "seller_sent_rate" => bind_column_value(sep, order.seller_sent_rate, style),
-        "failed_payment" => bind_column_value(sep, order.failed_payment, style),
-        "payment_attempts" => bind_column_value(sep, order.payment_attempts, style),
-        "expires_at" => bind_column_value(sep, order.expires_at, style),
-        "trade_index_seller" => bind_column_value(sep, order.trade_index_seller, style),
-        "trade_index_buyer" => bind_column_value(sep, order.trade_index_buyer, style),
-        "next_trade_pubkey" => bind_column_value(sep, &order.next_trade_pubkey, style),
-        "next_trade_index" => bind_column_value(sep, order.next_trade_index, style),
-        "cashu_mint_url" => bind_column_value(sep, &order.cashu_mint_url, style),
-        "cashu_escrow_token" => bind_column_value(sep, &order.cashu_escrow_token, style),
-        "cashu_escrow_locked_at" => bind_column_value(sep, order.cashu_escrow_locked_at, style),
-        other => panic!("unmapped order column: {other}"),
-    }
-}
-
-fn bind_column_value<'a, T>(
-    sep: &mut Separated<'_, 'a, Sqlite, &'static str>,
-    value: T,
-    style: BindStyle,
-) where
-    T: 'a + sqlx::Encode<'a, Sqlite> + sqlx::Type<Sqlite> + Send,
-{
-    match style {
-        BindStyle::Insert => {
-            sep.push_bind(value);
-        }
-        BindStyle::Update => {
-            sep.push_bind_unseparated(value);
-        }
-    }
-}
-
 fn push_order_insert_binds<'a>(b: &mut Separated<'_, 'a, Sqlite, &'static str>, order: &'a Order) {
-    for &column in ORDER_INSERT_COLUMNS {
-        bind_order_column(b, column, order, BindStyle::Insert);
-    }
+    b.push_bind(order.id)
+        .push_bind(&order.kind)
+        .push_bind(&order.event_id)
+        .push_bind(&order.hash)
+        .push_bind(&order.preimage)
+        .push_bind(&order.creator_pubkey)
+        .push_bind(&order.cancel_initiator_pubkey)
+        .push_bind(&order.buyer_pubkey)
+        .push_bind(&order.master_buyer_pubkey)
+        .push_bind(&order.seller_pubkey)
+        .push_bind(&order.master_seller_pubkey)
+        .push_bind(&order.status)
+        .push_bind(order.price_from_api)
+        .push_bind(order.premium)
+        .push_bind(&order.payment_method)
+        .push_bind(order.amount)
+        .push_bind(order.min_amount)
+        .push_bind(order.max_amount)
+        .push_bind(order.buyer_dispute)
+        .push_bind(order.seller_dispute)
+        .push_bind(order.buyer_cooperativecancel)
+        .push_bind(order.seller_cooperativecancel)
+        .push_bind(order.fee)
+        .push_bind(order.routing_fee)
+        .push_bind(order.dev_fee)
+        .push_bind(order.dev_fee_paid)
+        .push_bind(&order.dev_fee_payment_hash)
+        .push_bind(&order.fiat_code)
+        .push_bind(order.fiat_amount)
+        .push_bind(&order.buyer_invoice)
+        .push_bind(order.range_parent_id)
+        .push_bind(order.invoice_held_at)
+        .push_bind(order.taken_at)
+        .push_bind(order.created_at)
+        .push_bind(order.buyer_sent_rate)
+        .push_bind(order.seller_sent_rate)
+        .push_bind(order.failed_payment)
+        .push_bind(order.payment_attempts)
+        .push_bind(order.expires_at)
+        .push_bind(order.trade_index_seller)
+        .push_bind(order.trade_index_buyer)
+        .push_bind(&order.next_trade_pubkey)
+        .push_bind(order.next_trade_index)
+        .push_bind(&order.cashu_mint_url)
+        .push_bind(&order.cashu_escrow_token)
+        .push_bind(order.cashu_escrow_locked_at);
 }
 
 fn push_order_update_set<'a>(set: &mut Separated<'_, 'a, Sqlite, &'static str>, order: &'a Order) {
-    for &column in order_update_columns() {
-        bind_order_column(set, column, order, BindStyle::Update);
-    }
+    set.push("kind = ").push_bind_unseparated(&order.kind);
+    set.push("event_id = ")
+        .push_bind_unseparated(&order.event_id);
+    set.push("hash = ").push_bind_unseparated(&order.hash);
+    set.push("preimage = ")
+        .push_bind_unseparated(&order.preimage);
+    set.push("creator_pubkey = ")
+        .push_bind_unseparated(&order.creator_pubkey);
+    set.push("cancel_initiator_pubkey = ")
+        .push_bind_unseparated(&order.cancel_initiator_pubkey);
+    set.push("buyer_pubkey = ")
+        .push_bind_unseparated(&order.buyer_pubkey);
+    set.push("master_buyer_pubkey = ")
+        .push_bind_unseparated(&order.master_buyer_pubkey);
+    set.push("seller_pubkey = ")
+        .push_bind_unseparated(&order.seller_pubkey);
+    set.push("master_seller_pubkey = ")
+        .push_bind_unseparated(&order.master_seller_pubkey);
+    set.push("status = ").push_bind_unseparated(&order.status);
+    set.push("price_from_api = ")
+        .push_bind_unseparated(order.price_from_api);
+    set.push("premium = ").push_bind_unseparated(order.premium);
+    set.push("payment_method = ")
+        .push_bind_unseparated(&order.payment_method);
+    set.push("amount = ").push_bind_unseparated(order.amount);
+    set.push("min_amount = ")
+        .push_bind_unseparated(order.min_amount);
+    set.push("max_amount = ")
+        .push_bind_unseparated(order.max_amount);
+    set.push("buyer_dispute = ")
+        .push_bind_unseparated(order.buyer_dispute);
+    set.push("seller_dispute = ")
+        .push_bind_unseparated(order.seller_dispute);
+    set.push("buyer_cooperativecancel = ")
+        .push_bind_unseparated(order.buyer_cooperativecancel);
+    set.push("seller_cooperativecancel = ")
+        .push_bind_unseparated(order.seller_cooperativecancel);
+    set.push("fee = ").push_bind_unseparated(order.fee);
+    set.push("routing_fee = ")
+        .push_bind_unseparated(order.routing_fee);
+    set.push("dev_fee = ").push_bind_unseparated(order.dev_fee);
+    set.push("dev_fee_paid = ")
+        .push_bind_unseparated(order.dev_fee_paid);
+    set.push("dev_fee_payment_hash = ")
+        .push_bind_unseparated(&order.dev_fee_payment_hash);
+    set.push("fiat_code = ")
+        .push_bind_unseparated(&order.fiat_code);
+    set.push("fiat_amount = ")
+        .push_bind_unseparated(order.fiat_amount);
+    set.push("buyer_invoice = ")
+        .push_bind_unseparated(&order.buyer_invoice);
+    set.push("range_parent_id = ")
+        .push_bind_unseparated(order.range_parent_id);
+    set.push("invoice_held_at = ")
+        .push_bind_unseparated(order.invoice_held_at);
+    set.push("taken_at = ")
+        .push_bind_unseparated(order.taken_at);
+    set.push("created_at = ")
+        .push_bind_unseparated(order.created_at);
+    set.push("buyer_sent_rate = ")
+        .push_bind_unseparated(order.buyer_sent_rate);
+    set.push("seller_sent_rate = ")
+        .push_bind_unseparated(order.seller_sent_rate);
+    set.push("failed_payment = ")
+        .push_bind_unseparated(order.failed_payment);
+    set.push("payment_attempts = ")
+        .push_bind_unseparated(order.payment_attempts);
+    set.push("expires_at = ")
+        .push_bind_unseparated(order.expires_at);
+    set.push("trade_index_seller = ")
+        .push_bind_unseparated(order.trade_index_seller);
+    set.push("trade_index_buyer = ")
+        .push_bind_unseparated(order.trade_index_buyer);
+    set.push("next_trade_pubkey = ")
+        .push_bind_unseparated(&order.next_trade_pubkey);
+    set.push("next_trade_index = ")
+        .push_bind_unseparated(order.next_trade_index);
+    set.push("cashu_mint_url = ")
+        .push_bind_unseparated(&order.cashu_mint_url);
+    set.push("cashu_escrow_token = ")
+        .push_bind_unseparated(&order.cashu_escrow_token);
+    set.push("cashu_escrow_locked_at = ")
+        .push_bind_unseparated(order.cashu_escrow_locked_at);
 }
 
 impl Crud for Order {
@@ -212,18 +247,6 @@ mod tests {
     use crate::db::test_support::{sample_order, setup_pool};
     use crate::order::{Kind, Status};
     use uuid::Uuid;
-
-    /// Mirrors the INSERT bind loop in [`push_order_insert_binds`].
-    fn order_insert_bind_count() -> usize {
-        ORDER_INSERT_COLUMNS.len()
-    }
-
-    #[test]
-    fn insert_column_list_matches_bind_count() {
-        assert_eq!(ORDER_INSERT_COLUMNS.len(), order_insert_bind_count());
-        assert_eq!(ORDER_INSERT_COLUMNS.first(), Some(&"id"));
-        assert_eq!(order_update_columns().len(), ORDER_INSERT_COLUMNS.len() - 1);
-    }
 
     #[tokio::test]
     async fn create_by_id_roundtrip() {

--- a/src/db/order.rs
+++ b/src/db/order.rs
@@ -5,139 +5,156 @@ use sqlx::{query_builder::Separated, Pool, QueryBuilder, Sqlite};
 use crate::db::Crud;
 use crate::order::Order;
 
+/// Persisted `orders` columns, in [`Order`] field order. Keep in sync with
+/// `mostrod` migrations and [`Order`]'s `FromRow` mapping.
+const ORDER_INSERT_COLUMNS: &[&str] = &[
+    "id",
+    "kind",
+    "event_id",
+    "hash",
+    "preimage",
+    "creator_pubkey",
+    "cancel_initiator_pubkey",
+    "buyer_pubkey",
+    "master_buyer_pubkey",
+    "seller_pubkey",
+    "master_seller_pubkey",
+    "status",
+    "price_from_api",
+    "premium",
+    "payment_method",
+    "amount",
+    "min_amount",
+    "max_amount",
+    "buyer_dispute",
+    "seller_dispute",
+    "buyer_cooperativecancel",
+    "seller_cooperativecancel",
+    "fee",
+    "routing_fee",
+    "dev_fee",
+    "dev_fee_paid",
+    "dev_fee_payment_hash",
+    "fiat_code",
+    "fiat_amount",
+    "buyer_invoice",
+    "range_parent_id",
+    "invoice_held_at",
+    "taken_at",
+    "created_at",
+    "buyer_sent_rate",
+    "seller_sent_rate",
+    "failed_payment",
+    "payment_attempts",
+    "expires_at",
+    "trade_index_seller",
+    "trade_index_buyer",
+    "next_trade_pubkey",
+    "next_trade_index",
+    "cashu_mint_url",
+    "cashu_escrow_token",
+    "cashu_escrow_locked_at",
+];
+
+fn order_update_columns() -> &'static [&'static str] {
+    &ORDER_INSERT_COLUMNS[1..]
+}
+
+#[derive(Copy, Clone)]
+enum BindStyle {
+    Insert,
+    Update,
+}
+
+fn bind_order_column<'a>(
+    sep: &mut Separated<'_, 'a, Sqlite, &'static str>,
+    column: &str,
+    order: &'a Order,
+    style: BindStyle,
+) {
+    if matches!(style, BindStyle::Update) {
+        sep.push(column);
+        sep.push_unseparated(" = ");
+    }
+
+    match column {
+        "id" => bind_column_value(sep, order.id, style),
+        "kind" => bind_column_value(sep, &order.kind, style),
+        "event_id" => bind_column_value(sep, &order.event_id, style),
+        "hash" => bind_column_value(sep, &order.hash, style),
+        "preimage" => bind_column_value(sep, &order.preimage, style),
+        "creator_pubkey" => bind_column_value(sep, &order.creator_pubkey, style),
+        "cancel_initiator_pubkey" => bind_column_value(sep, &order.cancel_initiator_pubkey, style),
+        "buyer_pubkey" => bind_column_value(sep, &order.buyer_pubkey, style),
+        "master_buyer_pubkey" => bind_column_value(sep, &order.master_buyer_pubkey, style),
+        "seller_pubkey" => bind_column_value(sep, &order.seller_pubkey, style),
+        "master_seller_pubkey" => bind_column_value(sep, &order.master_seller_pubkey, style),
+        "status" => bind_column_value(sep, &order.status, style),
+        "price_from_api" => bind_column_value(sep, order.price_from_api, style),
+        "premium" => bind_column_value(sep, order.premium, style),
+        "payment_method" => bind_column_value(sep, &order.payment_method, style),
+        "amount" => bind_column_value(sep, order.amount, style),
+        "min_amount" => bind_column_value(sep, order.min_amount, style),
+        "max_amount" => bind_column_value(sep, order.max_amount, style),
+        "buyer_dispute" => bind_column_value(sep, order.buyer_dispute, style),
+        "seller_dispute" => bind_column_value(sep, order.seller_dispute, style),
+        "buyer_cooperativecancel" => bind_column_value(sep, order.buyer_cooperativecancel, style),
+        "seller_cooperativecancel" => bind_column_value(sep, order.seller_cooperativecancel, style),
+        "fee" => bind_column_value(sep, order.fee, style),
+        "routing_fee" => bind_column_value(sep, order.routing_fee, style),
+        "dev_fee" => bind_column_value(sep, order.dev_fee, style),
+        "dev_fee_paid" => bind_column_value(sep, order.dev_fee_paid, style),
+        "dev_fee_payment_hash" => bind_column_value(sep, &order.dev_fee_payment_hash, style),
+        "fiat_code" => bind_column_value(sep, &order.fiat_code, style),
+        "fiat_amount" => bind_column_value(sep, order.fiat_amount, style),
+        "buyer_invoice" => bind_column_value(sep, &order.buyer_invoice, style),
+        "range_parent_id" => bind_column_value(sep, order.range_parent_id, style),
+        "invoice_held_at" => bind_column_value(sep, order.invoice_held_at, style),
+        "taken_at" => bind_column_value(sep, order.taken_at, style),
+        "created_at" => bind_column_value(sep, order.created_at, style),
+        "buyer_sent_rate" => bind_column_value(sep, order.buyer_sent_rate, style),
+        "seller_sent_rate" => bind_column_value(sep, order.seller_sent_rate, style),
+        "failed_payment" => bind_column_value(sep, order.failed_payment, style),
+        "payment_attempts" => bind_column_value(sep, order.payment_attempts, style),
+        "expires_at" => bind_column_value(sep, order.expires_at, style),
+        "trade_index_seller" => bind_column_value(sep, order.trade_index_seller, style),
+        "trade_index_buyer" => bind_column_value(sep, order.trade_index_buyer, style),
+        "next_trade_pubkey" => bind_column_value(sep, &order.next_trade_pubkey, style),
+        "next_trade_index" => bind_column_value(sep, order.next_trade_index, style),
+        "cashu_mint_url" => bind_column_value(sep, &order.cashu_mint_url, style),
+        "cashu_escrow_token" => bind_column_value(sep, &order.cashu_escrow_token, style),
+        "cashu_escrow_locked_at" => bind_column_value(sep, order.cashu_escrow_locked_at, style),
+        other => panic!("unmapped order column: {other}"),
+    }
+}
+
+fn bind_column_value<'a, T>(
+    sep: &mut Separated<'_, 'a, Sqlite, &'static str>,
+    value: T,
+    style: BindStyle,
+) where
+    T: 'a + sqlx::Encode<'a, Sqlite> + sqlx::Type<Sqlite> + Send,
+{
+    match style {
+        BindStyle::Insert => {
+            sep.push_bind(value);
+        }
+        BindStyle::Update => {
+            sep.push_bind_unseparated(value);
+        }
+    }
+}
+
 fn push_order_insert_binds<'a>(b: &mut Separated<'_, 'a, Sqlite, &'static str>, order: &'a Order) {
-    b.push_bind(order.id)
-        .push_bind(&order.kind)
-        .push_bind(&order.event_id)
-        .push_bind(&order.hash)
-        .push_bind(&order.preimage)
-        .push_bind(&order.creator_pubkey)
-        .push_bind(&order.cancel_initiator_pubkey)
-        .push_bind(&order.buyer_pubkey)
-        .push_bind(&order.master_buyer_pubkey)
-        .push_bind(&order.seller_pubkey)
-        .push_bind(&order.master_seller_pubkey)
-        .push_bind(&order.status)
-        .push_bind(order.price_from_api)
-        .push_bind(order.premium)
-        .push_bind(&order.payment_method)
-        .push_bind(order.amount)
-        .push_bind(order.min_amount)
-        .push_bind(order.max_amount)
-        .push_bind(order.buyer_dispute)
-        .push_bind(order.seller_dispute)
-        .push_bind(order.buyer_cooperativecancel)
-        .push_bind(order.seller_cooperativecancel)
-        .push_bind(order.fee)
-        .push_bind(order.routing_fee)
-        .push_bind(order.dev_fee)
-        .push_bind(order.dev_fee_paid)
-        .push_bind(&order.dev_fee_payment_hash)
-        .push_bind(&order.fiat_code)
-        .push_bind(order.fiat_amount)
-        .push_bind(&order.buyer_invoice)
-        .push_bind(order.range_parent_id)
-        .push_bind(order.invoice_held_at)
-        .push_bind(order.taken_at)
-        .push_bind(order.created_at)
-        .push_bind(order.buyer_sent_rate)
-        .push_bind(order.seller_sent_rate)
-        .push_bind(order.failed_payment)
-        .push_bind(order.payment_attempts)
-        .push_bind(order.expires_at)
-        .push_bind(order.trade_index_seller)
-        .push_bind(order.trade_index_buyer)
-        .push_bind(&order.next_trade_pubkey)
-        .push_bind(order.next_trade_index)
-        .push_bind(&order.cashu_mint_url)
-        .push_bind(&order.cashu_escrow_token)
-        .push_bind(order.cashu_escrow_locked_at);
+    for &column in ORDER_INSERT_COLUMNS {
+        bind_order_column(b, column, order, BindStyle::Insert);
+    }
 }
 
 fn push_order_update_set<'a>(set: &mut Separated<'_, 'a, Sqlite, &'static str>, order: &'a Order) {
-    set.push("kind = ").push_bind_unseparated(&order.kind);
-    set.push("event_id = ")
-        .push_bind_unseparated(&order.event_id);
-    set.push("hash = ").push_bind_unseparated(&order.hash);
-    set.push("preimage = ")
-        .push_bind_unseparated(&order.preimage);
-    set.push("creator_pubkey = ")
-        .push_bind_unseparated(&order.creator_pubkey);
-    set.push("cancel_initiator_pubkey = ")
-        .push_bind_unseparated(&order.cancel_initiator_pubkey);
-    set.push("buyer_pubkey = ")
-        .push_bind_unseparated(&order.buyer_pubkey);
-    set.push("master_buyer_pubkey = ")
-        .push_bind_unseparated(&order.master_buyer_pubkey);
-    set.push("seller_pubkey = ")
-        .push_bind_unseparated(&order.seller_pubkey);
-    set.push("master_seller_pubkey = ")
-        .push_bind_unseparated(&order.master_seller_pubkey);
-    set.push("status = ").push_bind_unseparated(&order.status);
-    set.push("price_from_api = ")
-        .push_bind_unseparated(order.price_from_api);
-    set.push("premium = ").push_bind_unseparated(order.premium);
-    set.push("payment_method = ")
-        .push_bind_unseparated(&order.payment_method);
-    set.push("amount = ").push_bind_unseparated(order.amount);
-    set.push("min_amount = ")
-        .push_bind_unseparated(order.min_amount);
-    set.push("max_amount = ")
-        .push_bind_unseparated(order.max_amount);
-    set.push("buyer_dispute = ")
-        .push_bind_unseparated(order.buyer_dispute);
-    set.push("seller_dispute = ")
-        .push_bind_unseparated(order.seller_dispute);
-    set.push("buyer_cooperativecancel = ")
-        .push_bind_unseparated(order.buyer_cooperativecancel);
-    set.push("seller_cooperativecancel = ")
-        .push_bind_unseparated(order.seller_cooperativecancel);
-    set.push("fee = ").push_bind_unseparated(order.fee);
-    set.push("routing_fee = ")
-        .push_bind_unseparated(order.routing_fee);
-    set.push("dev_fee = ").push_bind_unseparated(order.dev_fee);
-    set.push("dev_fee_paid = ")
-        .push_bind_unseparated(order.dev_fee_paid);
-    set.push("dev_fee_payment_hash = ")
-        .push_bind_unseparated(&order.dev_fee_payment_hash);
-    set.push("fiat_code = ")
-        .push_bind_unseparated(&order.fiat_code);
-    set.push("fiat_amount = ")
-        .push_bind_unseparated(order.fiat_amount);
-    set.push("buyer_invoice = ")
-        .push_bind_unseparated(&order.buyer_invoice);
-    set.push("range_parent_id = ")
-        .push_bind_unseparated(order.range_parent_id);
-    set.push("invoice_held_at = ")
-        .push_bind_unseparated(order.invoice_held_at);
-    set.push("taken_at = ")
-        .push_bind_unseparated(order.taken_at);
-    set.push("created_at = ")
-        .push_bind_unseparated(order.created_at);
-    set.push("buyer_sent_rate = ")
-        .push_bind_unseparated(order.buyer_sent_rate);
-    set.push("seller_sent_rate = ")
-        .push_bind_unseparated(order.seller_sent_rate);
-    set.push("failed_payment = ")
-        .push_bind_unseparated(order.failed_payment);
-    set.push("payment_attempts = ")
-        .push_bind_unseparated(order.payment_attempts);
-    set.push("expires_at = ")
-        .push_bind_unseparated(order.expires_at);
-    set.push("trade_index_seller = ")
-        .push_bind_unseparated(order.trade_index_seller);
-    set.push("trade_index_buyer = ")
-        .push_bind_unseparated(order.trade_index_buyer);
-    set.push("next_trade_pubkey = ")
-        .push_bind_unseparated(&order.next_trade_pubkey);
-    set.push("next_trade_index = ")
-        .push_bind_unseparated(order.next_trade_index);
-    set.push("cashu_mint_url = ")
-        .push_bind_unseparated(&order.cashu_mint_url);
-    set.push("cashu_escrow_token = ")
-        .push_bind_unseparated(&order.cashu_escrow_token);
-    set.push("cashu_escrow_locked_at = ")
-        .push_bind_unseparated(order.cashu_escrow_locked_at);
+    for &column in order_update_columns() {
+        bind_order_column(set, column, order, BindStyle::Update);
+    }
 }
 
 impl Crud for Order {
@@ -147,52 +164,9 @@ impl Crud for Order {
             let mut qb = QueryBuilder::new("INSERT INTO orders (");
             {
                 let mut cols = qb.separated(", ");
-                cols.push("id");
-                cols.push("kind");
-                cols.push("event_id");
-                cols.push("hash");
-                cols.push("preimage");
-                cols.push("creator_pubkey");
-                cols.push("cancel_initiator_pubkey");
-                cols.push("buyer_pubkey");
-                cols.push("master_buyer_pubkey");
-                cols.push("seller_pubkey");
-                cols.push("master_seller_pubkey");
-                cols.push("status");
-                cols.push("price_from_api");
-                cols.push("premium");
-                cols.push("payment_method");
-                cols.push("amount");
-                cols.push("min_amount");
-                cols.push("max_amount");
-                cols.push("buyer_dispute");
-                cols.push("seller_dispute");
-                cols.push("buyer_cooperativecancel");
-                cols.push("seller_cooperativecancel");
-                cols.push("fee");
-                cols.push("routing_fee");
-                cols.push("dev_fee");
-                cols.push("dev_fee_paid");
-                cols.push("dev_fee_payment_hash");
-                cols.push("fiat_code");
-                cols.push("fiat_amount");
-                cols.push("buyer_invoice");
-                cols.push("range_parent_id");
-                cols.push("invoice_held_at");
-                cols.push("taken_at");
-                cols.push("created_at");
-                cols.push("buyer_sent_rate");
-                cols.push("seller_sent_rate");
-                cols.push("failed_payment");
-                cols.push("payment_attempts");
-                cols.push("expires_at");
-                cols.push("trade_index_seller");
-                cols.push("trade_index_buyer");
-                cols.push("next_trade_pubkey");
-                cols.push("next_trade_index");
-                cols.push("cashu_mint_url");
-                cols.push("cashu_escrow_token");
-                cols.push("cashu_escrow_locked_at");
+                for &column in ORDER_INSERT_COLUMNS {
+                    cols.push(column);
+                }
             }
             qb.push(") ");
             qb.push_values(std::iter::once(&self), |mut binds, order| {
@@ -238,6 +212,18 @@ mod tests {
     use crate::db::test_support::{sample_order, setup_pool};
     use crate::order::{Kind, Status};
     use uuid::Uuid;
+
+    /// Mirrors the INSERT bind loop in [`push_order_insert_binds`].
+    fn order_insert_bind_count() -> usize {
+        ORDER_INSERT_COLUMNS.len()
+    }
+
+    #[test]
+    fn insert_column_list_matches_bind_count() {
+        assert_eq!(ORDER_INSERT_COLUMNS.len(), order_insert_bind_count());
+        assert_eq!(ORDER_INSERT_COLUMNS.first(), Some(&"id"));
+        assert_eq!(order_update_columns().len(), ORDER_INSERT_COLUMNS.len() - 1);
+    }
 
     #[tokio::test]
     async fn create_by_id_roundtrip() {

--- a/src/dispute.rs
+++ b/src/dispute.rs
@@ -15,8 +15,6 @@ use nostr_sdk::Timestamp;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "sqlx")]
 use sqlx::{FromRow, Type};
-#[cfg(feature = "sqlx")]
-use sqlx_crud::SqlxCrud;
 use std::{fmt::Display, str::FromStr};
 use uuid::Uuid;
 
@@ -74,7 +72,7 @@ impl FromStr for Status {
 /// Disputes are always bound to a parent [`Order`]; `order_previous_status`
 /// preserves the status the order had before the dispute was filed so that
 /// it can be restored if the dispute is dismissed.
-#[cfg_attr(feature = "sqlx", derive(FromRow, SqlxCrud), external_id)]
+#[cfg_attr(feature = "sqlx", derive(FromRow))]
 #[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct Dispute {
     /// Unique identifier for the dispute.

--- a/src/message.rs
+++ b/src/message.rs
@@ -18,8 +18,6 @@ use bitcoin::secp256k1::Message as BitcoinMessage;
 use nostr_sdk::prelude::*;
 #[cfg(feature = "sqlx")]
 use sqlx::FromRow;
-#[cfg(feature = "sqlx")]
-use sqlx_crud::SqlxCrud;
 
 use std::fmt;
 use uuid::Uuid;
@@ -429,7 +427,7 @@ pub struct PaymentFailedInfo {
 ///
 /// Not intended as a general-purpose order representation — field names are
 /// chosen to match the SQL `SELECT` aliases used by the server query.
-#[cfg_attr(feature = "sqlx", derive(FromRow, SqlxCrud))]
+#[cfg_attr(feature = "sqlx", derive(FromRow))]
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct RestoredOrderHelper {
     /// Order id.
@@ -450,7 +448,7 @@ pub struct RestoredOrderHelper {
 ///
 /// Field names are chosen to match the SQL `SELECT` aliases in the restore
 /// query (in particular `status` is aliased as `dispute_status`).
-#[cfg_attr(feature = "sqlx", derive(FromRow, SqlxCrud))]
+#[cfg_attr(feature = "sqlx", derive(FromRow))]
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct RestoredDisputeHelper {
     /// Dispute id.
@@ -481,7 +479,7 @@ pub struct RestoredDisputeHelper {
 }
 
 /// Minimal per-order information returned to a client on session restore.
-#[cfg_attr(feature = "sqlx", derive(FromRow, SqlxCrud))]
+#[cfg_attr(feature = "sqlx", derive(FromRow))]
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct RestoredOrdersInfo {
     /// Id of the order.
@@ -505,7 +503,7 @@ pub enum DisputeInitiator {
 }
 
 /// Minimal per-dispute information returned to a client on session restore.
-#[cfg_attr(feature = "sqlx", derive(FromRow, SqlxCrud))]
+#[cfg_attr(feature = "sqlx", derive(FromRow))]
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct RestoredDisputesInfo {
     /// Id of the dispute.

--- a/src/order.rs
+++ b/src/order.rs
@@ -12,8 +12,6 @@ use nostr_sdk::{PublicKey, Timestamp};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "sqlx")]
 use sqlx::FromRow;
-#[cfg(feature = "sqlx")]
-use sqlx_crud::SqlxCrud;
 use std::{fmt::Display, str::FromStr};
 use uuid::Uuid;
 use wasm_bindgen::prelude::*;
@@ -166,7 +164,7 @@ impl FromStr for Status {
 ///
 /// Timestamps are Unix seconds; `hash` / `preimage` refer to the hold
 /// invoice used to lock the seller's funds.
-#[cfg_attr(feature = "sqlx", derive(FromRow, SqlxCrud), external_id)]
+#[cfg_attr(feature = "sqlx", derive(FromRow))]
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 pub struct Order {
     /// Unique order identifier.


### PR DESCRIPTION
## Summary

- Remove the `sqlx-crud` dependency and `SqlxCrud` derives from `Order`, `Dispute`, and the four `Restored*` helpers (they only need `FromRow`).
- Persistence for `Order` / `Dispute` is exclusively via `mostro_core::db::Crud` (landed in #154).
- Refactor `db/order.rs` to drive INSERT/UPDATE SQL from a single `ORDER_INSERT_COLUMNS` list, with a guard test so column names and bind loops cannot diverge.

Follow-up (separate `mostro` PR): implement `Crud` for `Bond`, switch daemon imports to `mostro_core::db::Crud`, and remove `sqlx-crud` from mostrod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined database integration by removing an optional CRUD helper dependency and updating the SQL feature wiring accordingly.
  * Simplified SQL-backed data mapping to rely on standard row mapping rather than added CRUD-derived behavior.
  * Improved order insertion SQL generation by using a single, consistent set of persisted insert columns to keep column binding and round-trip behavior aligned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->