### PR TITLE
feat: add optional fee_token to CashuLockProof

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -600,6 +600,12 @@ pub struct CashuLockProof {
     /// Mostro/arbitrator pubkey embedded in the 2-of-3 condition (`P_M`),
     /// hex.
     pub mostro_pubkey: String,
+    /// Serialized Cashu token locked 1-of-1 to `P_M`, carrying the Mostro fee
+    /// the seller funds alongside the escrow. `None` when the node charges no
+    /// fee. Omitted from the wire form when absent, so proofs without a fee
+    /// serialize exactly as before.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fee_token: Option<String>,
 }
 
 impl CashuLockProof {
@@ -617,7 +623,15 @@ impl CashuLockProof {
             buyer_pubkey,
             seller_pubkey,
             mostro_pubkey,
+            fee_token: None,
         }
+    }
+
+    /// Attach the seller-funded fee token (a Cashu token locked to `P_M`),
+    /// returning the updated proof.
+    pub fn with_fee_token(mut self, fee_token: String) -> Self {
+        self.fee_token = Some(fee_token);
+        self
     }
 
     /// Parse a [`CashuLockProof`] from its JSON representation.
@@ -2094,6 +2108,28 @@ mod test {
         let json = proof.as_json().unwrap();
         let back = CashuLockProof::from_json(&json).unwrap();
         assert_eq!(back, proof);
+    }
+
+    #[test]
+    fn test_cashu_lock_proof_fee_token_round_trip() {
+        let proof = sample_lock_proof().with_fee_token("cashuAfee".to_string());
+        let json = proof.as_json().unwrap();
+        assert!(json.contains("fee_token"));
+        let back = CashuLockProof::from_json(&json).unwrap();
+        assert_eq!(back, proof);
+        assert_eq!(back.fee_token.as_deref(), Some("cashuAfee"));
+    }
+
+    #[test]
+    fn test_cashu_lock_proof_without_fee_token_is_omitted_and_defaults_to_none() {
+        // A proof with no fee serializes without the key (wire-compatible with
+        // clients that predate the field) and parses back to `None`.
+        let proof = sample_lock_proof();
+        assert_eq!(proof.fee_token, None);
+        let json = proof.as_json().unwrap();
+        assert!(!json.contains("fee_token"));
+        let back = CashuLockProof::from_json(&json).unwrap();
+        assert_eq!(back.fee_token, None);
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds an optional `fee_token` field to `CashuLockProof`.

In the Cashu 2-of-3 escrow flow, Mostro is removed from the money path, so it
cannot skim its fee from the escrow token the way it does with Lightning hold
invoices. The agreed model (Track A spec, "funder-pays-at-lock") has the seller
fund the Mostro fee as a **separate** Cashu token locked 1-of-1 to `P_M`,
submitted alongside the 2-of-3 escrow token in the same `AddCashuEscrow`
message. This field carries that token.

## Changes (`src/message.rs`)

- **`CashuLockProof.fee_token: Option<String>`** — the serialized fee token.
  `None` when the node charges no fee.
  - `#[serde(default, skip_serializing_if = "Option::is_none")]` so the wire
    form is **backward- and forward-compatible**: an old client's proof (no
    `fee_token` key) deserializes to `None`, and a fee-less proof serializes
    **byte-identically** to before (key omitted, not `null`).
- **`new()` unchanged** — still 5 args, now sets `fee_token: None`; no existing
  caller breaks.
- **`with_fee_token(self, String) -> Self`** — immutable builder to attach the
  token opt-in.
- **`verify()` intentionally untouched** — it is a protocol-shape check with no
  access to `Settings`, so it cannot know whether the node charges a fee.
  Presence/amount of `fee_token` is validated daemon-side (config-dependent).

## Tests

- `test_cashu_lock_proof_fee_token_round_trip` — `with_fee_token` → JSON
  contains `fee_token` → round-trips preserving `Some`.
- `test_cashu_lock_proof_without_fee_token_is_omitted_and_defaults_to_none` —
  fee-less proof omits the key and parses back to `None`.
- Existing `CashuLockProof` / `verify()` tests pass unmodified.

`cargo fmt --check`, `clippy --all-targets --all-features -D warnings`, and the
full test suite (83 lib + 4 doc-tests) are green.

## Notes

- **No version bump** — left for the maintainer's `cargo release` flow.
- Additive and backward-compatible; the daemon-side handler and the wider Cashu
  escrow spec live in the `mostro` repo (`docs/cashu/02-track-a-lock.md`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for attaching an optional fee token to lock proofs.
  * Fee token data now persists through save/load flows when present.
  * Empty fee token values are omitted automatically, keeping the output cleaner.

* **Tests**
  * Added coverage for round-trip behavior with and without a fee token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->