### PR TITLE
feat(chat): gift-wrap-free kind 14 envelope (K_conv / K_sign)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,9 @@ sqlx = { version = "0.9.0", features = [
 wasm-bindgen = { version = "0.2.92", optional = true }
 nostr-sdk = { version = "0.44.1", features = ["nip44", "nip59"] }
 bitcoin = "0.32.7"
+# Leading `::hkdf` in chat code avoids ambiguity with `nostr_sdk::prelude::hkdf`.
+hkdf = "0.12"
+sha2 = "0.10"
 
 [features]
 default = ["wasm"]

--- a/src/chat/filter.rs
+++ b/src/chat/filter.rs
@@ -1,30 +1,39 @@
-//! Build a Nostr relay filter for Mostro P2P chat gift wraps.
+//! Build Nostr relay filters for Mostro P2P chat.
 //!
-//! Chat gift wraps are addressable by the shared key's public key (carried
-//! in the outer `p` tag), so a single filter retrieves both directions of
-//! the conversation regardless of which trade key authored each message.
+//! The gift-wrap-free envelope is addressable by **`authors = [pub(K_sign)]`**.
+//! Filtering only by `#p` reintroduces third-party flooding — see
+//! <https://mostro.network/protocol/chat.html#subscription>.
 
 use nostr_sdk::prelude::*;
 
-/// Default lookback window applied by [`chat_filter`] (7 days).
-///
-/// Mostro chat sessions are short-lived (a trade lasts at most a few days),
-/// so a one-week window covers active disputes without dragging back
-/// arbitrarily old wraps.
+/// Default lookback window applied by [`chat_filter`] / [`giftwrap_chat_filter`]
+/// (7 days).
 pub const CHAT_DEFAULT_LOOKBACK_SECS: u64 = 7 * 24 * 60 * 60;
 
-/// Create a Nostr relay filter for chat gift wraps addressed to a shared
-/// public key.
+/// Relay filter for kind 14 chat events authored by `pub(K_sign)`.
 ///
-/// The returned filter matches:
+/// Matches:
 ///
-/// * `kind == 1059` ([`Kind::GiftWrap`]),
-/// * presence of a `p` tag equal to `shared_pubkey`,
+/// * `kind == 14` ([`Kind::PrivateDirectMessage`]),
+/// * `authors = [sign_pubkey]`,
 /// * `created_at >= now - CHAT_DEFAULT_LOOKBACK_SECS`.
 ///
-/// Callers can chain extra constraints (e.g. `.limit(...)` or override
-/// `.since(...)`) before subscribing.
-pub fn chat_filter(shared_pubkey: PublicKey) -> Filter {
+/// Callers SHOULD also chain `.limit(...)` and may override `.since(...)` with
+/// a persisted cursor (never advanced past local now).
+pub fn chat_filter(sign_pubkey: PublicKey) -> Filter {
+    let since = Timestamp::now()
+        .as_secs()
+        .saturating_sub(CHAT_DEFAULT_LOOKBACK_SECS);
+    Filter::new()
+        .kind(Kind::PrivateDirectMessage)
+        .author(sign_pubkey)
+        .since(Timestamp::from_secs(since))
+}
+
+/// Legacy gift-wrap filter (`kind: 1059`, `#p = shared_pubkey`).
+///
+/// Prefer [`chat_filter`]. Kept for dual-read hydration during migration.
+pub fn giftwrap_chat_filter(shared_pubkey: PublicKey) -> Filter {
     let since = Timestamp::now()
         .as_secs()
         .saturating_sub(CHAT_DEFAULT_LOOKBACK_SECS);
@@ -39,9 +48,33 @@ mod tests {
     use super::*;
 
     #[test]
-    fn filter_targets_gift_wrap_kind_and_pubkey() {
+    fn filter_targets_kind14_and_author() {
         let pk = Keys::generate().public_key();
         let filter = chat_filter(pk);
+        let json = serde_json::to_value(&filter).expect("filter json");
+
+        let kinds = json.get("kinds").expect("kinds present");
+        assert!(kinds
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|k| k.as_u64() == Some(14)));
+
+        let authors = json.get("authors").expect("authors present");
+        assert!(authors
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|v| v.as_str() == Some(&pk.to_hex())));
+
+        assert!(json.get("since").is_some());
+        assert!(json.get("#p").is_none());
+    }
+
+    #[test]
+    fn giftwrap_filter_targets_kind_and_pubkey() {
+        let pk = Keys::generate().public_key();
+        let filter = giftwrap_chat_filter(pk);
         let json = serde_json::to_value(&filter).expect("filter json");
 
         let kinds = json.get("kinds").expect("kinds present");
@@ -57,7 +90,5 @@ mod tests {
             .unwrap()
             .iter()
             .any(|v| v.as_str() == Some(&pk.to_hex())));
-
-        assert!(json.get("since").is_some());
     }
 }

--- a/src/chat/keys.rs
+++ b/src/chat/keys.rs
@@ -1,0 +1,148 @@
+//! Domain-separated chat key derivation (`K_conv` / `K_sign`).
+//!
+//! The ECDH shared secret between two trade keys (or admin ↔ party trade key)
+//! is **not** used on the wire. HKDF-SHA256 splits it into:
+//!
+//! * [`K_conv`](derive_chat_keys) — NIP-44 encryption and the outer `p` tag
+//! * [`K_sign`](derive_chat_keys) — signs the outer kind 14 event (author filter)
+//!
+//! See <https://mostro.network/protocol/chat.html#key-derivation>.
+
+// Leading `::` selects the `hkdf` crate: `nostr_sdk::prelude` also exports a
+// module by that name, so a plain `use hkdf::Hkdf` is ambiguous.
+use ::hkdf::Hkdf;
+use nostr_sdk::prelude::*;
+use sha2::Sha256;
+
+use crate::error::{MostroError, ServiceError};
+
+/// HKDF `info` for `K_conv`. Changing this value changes the wire format.
+pub const CHAT_CONV_INFO: &[u8] = b"mostro:chat:conv:v1";
+/// HKDF `info` for `K_sign`. Changing this value changes the wire format.
+pub const CHAT_SIGN_INFO: &[u8] = b"mostro:chat:sign:v1";
+
+/// Derive `(K_conv, K_sign)` from a party's trade keys and the peer's trade pubkey.
+///
+/// Both peers obtain the same pair by swapping arguments
+/// (`A.derive(a, B) == B.derive(b, A)`).
+pub fn derive_chat_keys(
+    own_trade: &Keys,
+    peer_trade: &PublicKey,
+) -> Result<(Keys, Keys), MostroError> {
+    let shared =
+        nostr_sdk::util::generate_shared_key(own_trade.secret_key(), peer_trade).map_err(|e| {
+            MostroError::MostroInternalErr(ServiceError::EncryptionError(format!(
+                "chat ECDH failed: {e}"
+            )))
+        })?;
+    derive_chat_keys_from_shared(&shared)
+}
+
+/// Derive `(K_conv, K_sign)` from an already-computed 32-byte ECDH secret.
+///
+/// Clients that persist the ECDH output (e.g. Mostrix `order_chat_shared_key_hex`)
+/// call this on load instead of re-running ECDH.
+pub fn derive_chat_keys_from_shared(shared: &[u8]) -> Result<(Keys, Keys), MostroError> {
+    if shared.len() != 32 {
+        return Err(MostroError::MostroInternalErr(
+            ServiceError::EncryptionError(format!(
+                "chat shared secret must be 32 bytes, got {}",
+                shared.len()
+            )),
+        ));
+    }
+    let hkdf = Hkdf::<Sha256>::new(None, shared);
+
+    let derive = |info: &[u8]| -> Result<Keys, MostroError> {
+        // Retry with a counter byte on the negligible chance that the output
+        // is not a valid secp256k1 secret key (spec requirement).
+        for counter in 0u16..=255 {
+            let mut labelled = info.to_vec();
+            if counter > 0 {
+                labelled.push(counter as u8);
+            }
+            let mut out = [0u8; 32];
+            hkdf.expand(&labelled, &mut out).map_err(|e| {
+                MostroError::MostroInternalErr(ServiceError::EncryptionError(format!(
+                    "HKDF expand failed: {e}"
+                )))
+            })?;
+            if let Ok(sk) = SecretKey::from_slice(&out) {
+                return Ok(Keys::new(sk));
+            }
+        }
+        Err(MostroError::MostroInternalErr(
+            ServiceError::EncryptionError("HKDF failed to produce a valid secret key".to_string()),
+        ))
+    };
+
+    Ok((derive(CHAT_CONV_INFO)?, derive(CHAT_SIGN_INFO)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Published test vector from <https://mostro.network/protocol/chat.html#test-vector>.
+    #[test]
+    fn protocol_test_vector_derived_pubkeys() {
+        let alice = Keys::parse("548f68890c49fa42f104c60352395e60ff030b0b407e955f1eed1400d6c0347a")
+            .unwrap();
+        let bob = Keys::parse("f258e73f07386d37133718b6127f873dd7c391b8f43b331ff8254034a13d2943")
+            .unwrap();
+
+        assert_eq!(
+            alice.public_key().to_hex(),
+            "000053c3b4773182e7c4c1b72b272d34be01bf4414a6a25c998977c516a46a01"
+        );
+        assert_eq!(
+            bob.public_key().to_hex(),
+            "000009ae5cff9f6ba9b05159ec5ed58c187f5882ea77c81ed5dd19163272a5d7"
+        );
+
+        let shared =
+            nostr_sdk::util::generate_shared_key(alice.secret_key(), &bob.public_key()).unwrap();
+        let expected_shared =
+            SecretKey::from_hex("def6633a53d07d1e829484c4d4bdbbeed2f4b14c21743e63871c174338e39475")
+                .unwrap()
+                .to_secret_bytes();
+        assert_eq!(shared, expected_shared);
+
+        let (alice_conv, alice_sign) = derive_chat_keys(&alice, &bob.public_key()).unwrap();
+        let (bob_conv, bob_sign) = derive_chat_keys(&bob, &alice.public_key()).unwrap();
+
+        assert_eq!(alice_conv.public_key(), bob_conv.public_key());
+        assert_eq!(alice_sign.public_key(), bob_sign.public_key());
+        assert_eq!(
+            alice_conv.public_key().to_hex(),
+            "bceb1cd2a8e98ee9729122a1693edcc39c3ace04582ff96a26705c5e4078a6f2"
+        );
+        assert_eq!(
+            alice_sign.public_key().to_hex(),
+            "1dba04571059183f76b148119cfa6f8004dad30cb4e810180a6df17386a7f0b4"
+        );
+
+        let from_shared = derive_chat_keys_from_shared(&shared).unwrap();
+        assert_eq!(from_shared.0.public_key(), alice_conv.public_key());
+        assert_eq!(from_shared.1.public_key(), alice_sign.public_key());
+    }
+
+    #[test]
+    fn k_conv_cannot_derive_k_sign() {
+        let alice = Keys::generate();
+        let bob = Keys::generate();
+        let (conv, sign) = derive_chat_keys(&alice, &bob.public_key()).unwrap();
+        // Holding only K_conv must not yield K_sign (observer is read-only).
+        assert_ne!(
+            conv.secret_key().to_secret_bytes(),
+            sign.secret_key().to_secret_bytes()
+        );
+        assert_ne!(conv.public_key(), sign.public_key());
+    }
+
+    #[test]
+    fn derive_from_shared_rejects_wrong_length() {
+        let err = derive_chat_keys_from_shared(&[0u8; 16]).unwrap_err();
+        assert!(matches!(err, MostroError::MostroInternalErr(_)));
+    }
+}

--- a/src/chat/mod.rs
+++ b/src/chat/mod.rs
@@ -1,60 +1,69 @@
 //! Mostro P2P chat protocol primitives.
 //!
-//! Mostro reuses the NIP-59 GiftWrap envelope to carry a second, lighter
-//! channel: direct buyer/seller chat during a trade and admin/party chat
-//! during a dispute. Unlike protocol messages — which are addressed to a
-//! Mostro node and use the dual identity/trade key scheme of
-//! [`crate::nip59`] — chat envelopes are addressed to a per-channel
-//! **shared key** that both parties derive via ECDH from their trade keys.
-//!
-//! The on-the-wire shape is intentionally simple:
+//! Buyer/seller (and admin/party dispute) chat excludes the Mostro daemon.
+//! Messages use a **kind 14** envelope signed by `K_sign`, carrying a NIP-44
+//! encrypted kind 1 event signed by the sender's trade key. Keys are derived
+//! from the parties' ECDH secret via HKDF domain separation into `K_conv`
+//! (encrypt / `p` tag) and `K_sign` (outer author).
 //!
 //! ```text
 //! Plain-text message
 //!     -> kind 1 TextNote signed by sender_trade_keys (inner)
-//!     -> NIP-44 v2 encrypt to shared_pubkey using an ephemeral key
-//!     -> kind 1059 GiftWrap with `p` = shared_pubkey, signed ephemerally
+//!     -> NIP-44 v2 self-encrypt under K_conv
+//!     -> kind 14, p = pub(K_conv), signed by K_sign (outer)
 //! ```
 //!
-//! Both parties can fetch and decrypt every wrap addressed to the shared
-//! key, and the inner event's signature carries the real sender's trade
-//! pubkey so each side can render the conversation correctly without
-//! exchanging extra metadata.
+//! Clients MUST subscribe with `authors = [pub(K_sign)]` — see [`chat_filter`].
+//! Filtering by `#p` alone is vulnerable to third-party flooding.
 //!
-//! This module is **pure protocol**: it derives shared keys, builds and
-//! parses envelopes, and constructs the relay filter. It does not manage
-//! relays, subscriptions, persistence or higher-level workflows — those
-//! belong to the client.
+//! Legacy gift-wrap helpers ([`wrap_giftwrap_chat_message`],
+//! [`unwrap_giftwrap_chat_message`], [`giftwrap_chat_filter`]) remain for a
+//! dual-read migration window.
+//!
+//! Spec: <https://mostro.network/protocol/chat.html>
 //!
 //! ## Quick start
 //!
 //! ```no_run
 //! # async fn run() -> Result<(), mostro_core::error::MostroError> {
-//! use mostro_core::chat::{chat_filter, wrap_chat_message, unwrap_chat_message, SharedKey};
+//! use mostro_core::chat::{
+//!     chat_filter, derive_chat_keys, unwrap_chat_message, wrap_chat_message,
+//! };
 //! use nostr_sdk::prelude::*;
 //!
 //! let alice = Keys::generate();
-//! let bob_pubkey = Keys::generate().public_key();
+//! let bob = Keys::generate();
 //!
-//! let shared = SharedKey::derive(alice.secret_key(), &bob_pubkey)?;
-//! let event = wrap_chat_message(&alice, &shared.public_key(), "hi bob").await?;
+//! let (conv, sign) = derive_chat_keys(&alice, &bob.public_key())?;
+//! let event = wrap_chat_message(&alice, &conv, &sign, "hi bob").await?;
 //!
-//! // ...publish `event` to relays, fetch incoming wraps with `chat_filter(...)`,
-//! // then on the receiving side:
-//! let chat = unwrap_chat_message(shared.keys(), &event).await?;
+//! // Subscribe with chat_filter(sign.public_key()), then:
+//! let allowed = [alice.public_key(), bob.public_key()];
+//! let chat = unwrap_chat_message(
+//!     &conv,
+//!     &sign.public_key(),
+//!     &allowed,
+//!     &event,
+//!     Timestamp::now(),
+//! )?;
 //! assert_eq!(chat.content, "hi bob");
 //! # Ok(()) }
 //! ```
 
 mod filter;
+mod keys;
 mod shared_key;
 mod unwrap;
 mod wrap;
 
-pub use filter::{chat_filter, CHAT_DEFAULT_LOOKBACK_SECS};
+pub use filter::{chat_filter, giftwrap_chat_filter, CHAT_DEFAULT_LOOKBACK_SECS};
+pub use keys::{derive_chat_keys, derive_chat_keys_from_shared, CHAT_CONV_INFO, CHAT_SIGN_INFO};
 pub use shared_key::SharedKey;
-pub use unwrap::{unwrap_chat_message, ChatMessage};
-pub use wrap::wrap_chat_message;
+pub use unwrap::{
+    unwrap_chat_message, unwrap_giftwrap_chat_message, ChatMessage, CHAT_MAX_CLOCK_SKEW_SECS,
+    CHAT_MAX_CONTENT_BYTES,
+};
+pub use wrap::{wrap_chat_message, wrap_chat_message_with_tags, wrap_giftwrap_chat_message};
 
 #[cfg(test)]
 mod tests {
@@ -62,51 +71,49 @@ mod tests {
     use nostr_sdk::nips::nip44;
     use nostr_sdk::prelude::*;
 
-    fn shared_pair() -> (Keys, Keys, SharedKey, SharedKey) {
+    fn chat_pair() -> (Keys, Keys, Keys, Keys) {
         let alice = Keys::generate();
         let bob = Keys::generate();
-        let alice_shared = SharedKey::derive(alice.secret_key(), &bob.public_key()).unwrap();
-        let bob_shared = SharedKey::derive(bob.secret_key(), &alice.public_key()).unwrap();
-        (alice, bob, alice_shared, bob_shared)
+        let (conv, sign) = derive_chat_keys(&alice, &bob.public_key()).unwrap();
+        (alice, bob, conv, sign)
     }
 
     #[tokio::test]
     async fn wrap_and_unwrap_roundtrip() {
-        let (alice, _bob, alice_shared, bob_shared) = shared_pair();
+        let (alice, bob, conv, sign) = chat_pair();
         let body = "hello from alice";
 
-        let event = wrap_chat_message(&alice, &alice_shared.public_key(), body)
+        let event = wrap_chat_message(&alice, &conv, &sign, body)
             .await
             .expect("wrap");
 
-        assert_eq!(event.kind, Kind::GiftWrap);
-        assert!(event
-            .tags
-            .public_keys()
-            .any(|pk| *pk == alice_shared.public_key()));
+        assert_eq!(event.kind, Kind::PrivateDirectMessage);
+        assert_eq!(event.pubkey, sign.public_key());
+        assert!(event.tags.public_keys().any(|pk| *pk == conv.public_key()));
 
-        let decoded = unwrap_chat_message(bob_shared.keys(), &event)
-            .await
-            .expect("unwrap");
+        let allowed = [alice.public_key(), bob.public_key()];
+        let decoded = unwrap_chat_message(
+            &conv,
+            &sign.public_key(),
+            &allowed,
+            &event,
+            Timestamp::now(),
+        )
+        .expect("unwrap");
 
         assert_eq!(decoded.content, body);
         assert_eq!(decoded.sender, alice.public_key());
     }
 
     #[tokio::test]
-    async fn unwrap_with_wrong_shared_key_fails() {
-        let (alice, _bob, alice_shared, _bob_shared) = shared_pair();
-        let intruder = Keys::generate();
-        let intruder_shared =
-            SharedKey::derive(intruder.secret_key(), &Keys::generate().public_key()).unwrap();
+    async fn unwrap_rejects_wrong_author() {
+        let (alice, bob, conv, sign) = chat_pair();
+        let event = wrap_chat_message(&alice, &conv, &sign, "hi").await.unwrap();
 
-        let event = wrap_chat_message(&alice, &alice_shared.public_key(), "for bob only")
-            .await
-            .expect("wrap");
-
-        let err = unwrap_chat_message(intruder_shared.keys(), &event)
-            .await
-            .expect_err("must not decrypt with foreign shared key");
+        let impostor = Keys::generate().public_key();
+        let allowed = [alice.public_key(), bob.public_key()];
+        let err = unwrap_chat_message(&conv, &impostor, &allowed, &event, Timestamp::now())
+            .expect_err("wrong author");
         assert!(matches!(
             err,
             crate::error::MostroError::MostroInternalErr(_)
@@ -114,64 +121,219 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unwrap_tampered_event_fails() {
-        let (_alice, _bob, alice_shared, bob_shared) = shared_pair();
-
-        // Build a wrap whose inner ciphertext is the encryption of an event
-        // signed by an *impostor*, not by `alice`. The outer envelope is
-        // perfectly valid (ephemeral key signs it), but the inner signature
-        // must not verify against the rumor pubkey.
-        let impostor = Keys::generate();
-        let inner = EventBuilder::text_note("forged")
-            .build(impostor.public_key())
-            .sign(&impostor)
-            .await
-            .unwrap();
-
-        // Mutate the signed event JSON so the signature no longer matches
-        // its content — `verify()` should reject it.
-        let mut json: serde_json::Value = serde_json::from_str(&inner.as_json()).unwrap();
-        json["content"] = serde_json::Value::String("tampered".to_string());
-        let tampered_inner = json.to_string();
-
-        let ephemeral = Keys::generate();
-        let encrypted = nip44::encrypt(
-            ephemeral.secret_key(),
-            &alice_shared.public_key(),
-            tampered_inner,
-            nip44::Version::V2,
-        )
-        .unwrap();
-        let event = EventBuilder::new(Kind::GiftWrap, encrypted)
-            .tag(Tag::public_key(alice_shared.public_key()))
-            .sign_with_keys(&ephemeral)
-            .unwrap();
-
-        let err = unwrap_chat_message(bob_shared.keys(), &event)
-            .await
-            .expect_err("tampered inner must not verify");
-        assert!(matches!(
-            err,
-            crate::error::MostroError::MostroInternalErr(_)
-        ));
-    }
-
-    #[tokio::test]
-    async fn unwrap_rejects_non_giftwrap_event() {
-        let alice = Keys::generate();
-        let other = Keys::generate();
-        let shared = SharedKey::derive(alice.secret_key(), &other.public_key()).unwrap();
-
-        // A plain text note is the wrong kind for the outer envelope.
-        let bogus = EventBuilder::text_note("not a wrap")
+    async fn unwrap_rejects_wrong_p_tag() {
+        let (alice, bob, conv, sign) = chat_pair();
+        let now = Timestamp::now();
+        let inner = EventBuilder::text_note("hi")
+            .custom_created_at(now)
             .build(alice.public_key())
             .sign(&alice)
             .await
             .unwrap();
+        let content = nip44::encrypt(
+            conv.secret_key(),
+            &conv.public_key(),
+            inner.as_json(),
+            nip44::Version::V2,
+        )
+        .unwrap();
+        let wrong_p = Keys::generate().public_key();
+        let event = EventBuilder::new(Kind::PrivateDirectMessage, content)
+            .tag(Tag::public_key(wrong_p))
+            .custom_created_at(now)
+            .sign_with_keys(&sign)
+            .unwrap();
 
-        let err = unwrap_chat_message(shared.keys(), &bogus)
+        let allowed = [alice.public_key(), bob.public_key()];
+        let err = unwrap_chat_message(
+            &conv,
+            &sign.public_key(),
+            &allowed,
+            &event,
+            Timestamp::now(),
+        )
+        .expect_err("wrong p");
+        assert!(matches!(
+            err,
+            crate::error::MostroError::MostroInternalErr(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn unwrap_rejects_future_timestamp() {
+        let (alice, bob, conv, sign) = chat_pair();
+        let far_future = Timestamp::from_secs(Timestamp::now().as_secs() + 3600);
+        let inner = EventBuilder::text_note("hi")
+            .custom_created_at(far_future)
+            .build(alice.public_key())
+            .sign(&alice)
             .await
-            .expect_err("non-giftwrap must error");
+            .unwrap();
+        let content = nip44::encrypt(
+            conv.secret_key(),
+            &conv.public_key(),
+            inner.as_json(),
+            nip44::Version::V2,
+        )
+        .unwrap();
+        let event = EventBuilder::new(Kind::PrivateDirectMessage, content)
+            .tag(Tag::public_key(conv.public_key()))
+            .custom_created_at(far_future)
+            .sign_with_keys(&sign)
+            .unwrap();
+
+        let allowed = [alice.public_key(), bob.public_key()];
+        let err = unwrap_chat_message(
+            &conv,
+            &sign.public_key(),
+            &allowed,
+            &event,
+            Timestamp::now(),
+        )
+        .expect_err("future");
+        assert!(matches!(
+            err,
+            crate::error::MostroError::MostroInternalErr(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn unwrap_rejects_oversized_content() {
+        let (alice, bob, conv, sign) = chat_pair();
+        let now = Timestamp::now();
+        let huge = "x".repeat(CHAT_MAX_CONTENT_BYTES + 1);
+        let event = EventBuilder::new(Kind::PrivateDirectMessage, huge)
+            .tag(Tag::public_key(conv.public_key()))
+            .custom_created_at(now)
+            .sign_with_keys(&sign)
+            .unwrap();
+
+        let allowed = [alice.public_key(), bob.public_key()];
+        let err = unwrap_chat_message(
+            &conv,
+            &sign.public_key(),
+            &allowed,
+            &event,
+            Timestamp::now(),
+        )
+        .expect_err("oversized");
+        assert!(matches!(
+            err,
+            crate::error::MostroError::MostroInternalErr(_)
+        ));
+        // Author/p/size checks run before decrypt — bogus ciphertext is fine.
+        let _ = alice;
+    }
+
+    #[tokio::test]
+    async fn unwrap_rejects_non_party_inner_signer() {
+        let (alice, bob, conv, sign) = chat_pair();
+        let intruder = Keys::generate();
+        let now = Timestamp::now();
+        let inner = EventBuilder::text_note("forged")
+            .custom_created_at(now)
+            .build(intruder.public_key())
+            .sign(&intruder)
+            .await
+            .unwrap();
+        let content = nip44::encrypt(
+            conv.secret_key(),
+            &conv.public_key(),
+            inner.as_json(),
+            nip44::Version::V2,
+        )
+        .unwrap();
+        let event = EventBuilder::new(Kind::PrivateDirectMessage, content)
+            .tag(Tag::public_key(conv.public_key()))
+            .custom_created_at(now)
+            .sign_with_keys(&sign)
+            .unwrap();
+
+        let allowed = [alice.public_key(), bob.public_key()];
+        let err = unwrap_chat_message(
+            &conv,
+            &sign.public_key(),
+            &allowed,
+            &event,
+            Timestamp::now(),
+        )
+        .expect_err("non-party");
+        assert!(matches!(
+            err,
+            crate::error::MostroError::MostroInternalErr(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn observer_with_k_conv_only_can_decrypt_but_not_sign() {
+        let (alice, bob, conv, sign) = chat_pair();
+        let event = wrap_chat_message(&alice, &conv, &sign, "evidence")
+            .await
+            .unwrap();
+
+        // Observer holds K_conv only (e.g. Keys::new from disclosed secret).
+        let observer_conv =
+            Keys::new(SecretKey::from_slice(conv.secret_key().as_secret_bytes()).unwrap());
+        let allowed = [alice.public_key(), bob.public_key()];
+        let msg = unwrap_chat_message(
+            &observer_conv,
+            &sign.public_key(),
+            &allowed,
+            &event,
+            Timestamp::now(),
+        )
+        .expect("observer decrypt");
+        assert_eq!(msg.content, "evidence");
+
+        // Without K_sign the observer cannot author a valid outer event.
+        let forged = wrap_chat_message(&alice, &observer_conv, &observer_conv, "inject")
+            .await
+            .unwrap();
+        assert_ne!(forged.pubkey, sign.public_key());
+        let err = unwrap_chat_message(
+            &conv,
+            &sign.public_key(),
+            &allowed,
+            &forged,
+            Timestamp::now(),
+        )
+        .expect_err("observer cannot forge author");
+        assert!(matches!(
+            err,
+            crate::error::MostroError::MostroInternalErr(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn giftwrap_legacy_roundtrip_still_works() {
+        let alice = Keys::generate();
+        let bob = Keys::generate();
+        let shared = SharedKey::derive(alice.secret_key(), &bob.public_key()).unwrap();
+
+        let event = wrap_giftwrap_chat_message(&alice, &shared.public_key(), "legacy")
+            .await
+            .unwrap();
+        assert_eq!(event.kind, Kind::GiftWrap);
+
+        let decoded = unwrap_giftwrap_chat_message(shared.keys(), &event)
+            .await
+            .unwrap();
+        assert_eq!(decoded.content, "legacy");
+        assert_eq!(decoded.sender, alice.public_key());
+    }
+
+    #[tokio::test]
+    async fn wrap_rejects_extra_p_tag() {
+        let (alice, _bob, conv, sign) = chat_pair();
+        let err = wrap_chat_message_with_tags(
+            &alice,
+            &conv,
+            &sign,
+            "hi",
+            vec![Tag::public_key(Keys::generate().public_key())],
+        )
+        .await
+        .expect_err("extra p");
         assert!(matches!(
             err,
             crate::error::MostroError::MostroInternalErr(_)

--- a/src/chat/shared_key.rs
+++ b/src/chat/shared_key.rs
@@ -1,30 +1,31 @@
-//! ECDH-derived shared key used as the addressable identity of a Mostro
-//! P2P chat channel.
+//! ECDH shared secret used as IKM for Mostro P2P chat key derivation.
 //!
 //! The two parties of a chat (buyer/seller during a trade or admin/party
-//! during a dispute) each compute the same `SharedKey` from their own trade
-//! secret key and the counterparty's trade public key, so both can encrypt
-//! and decrypt the conversation, and so relays can route gift wraps through
-//! a `p` tag bound to the shared public key — without leaking either real
-//! pubkey on the wire.
+//! during a dispute) each compute the same 32-byte ECDH output from their
+//! own secret key and the counterparty's public key. That output is the
+//! input keying material for [`crate::chat::derive_chat_keys_from_shared`],
+//! which produces `K_conv` and `K_sign`.
+//!
+//! Clients MAY persist the ECDH secret (via [`SharedKey::to_hex`]) and
+//! re-derive chat keys on load. The ECDH secret itself is **not** the wire
+//! address: `pub(K_conv)` is the `p` tag and `pub(K_sign)` is the author.
 
 use nostr_sdk::prelude::*;
 
+use crate::chat::keys::derive_chat_keys_from_shared;
 use crate::error::{MostroError, ServiceError};
 
-/// Shared key derived via ECDH between two parties' trade keys.
+/// Shared ECDH secret between two parties' trade (or admin) keys.
 ///
 /// Internally a `Keys` instance whose secret is the 32-byte ECDH output of
-/// `(local_secret, counterparty_pubkey)`. Both sides of the conversation
-/// derive an identical value and therefore an identical public key, which
-/// is what gift wraps are addressed to.
+/// `(local_secret, counterparty_pubkey)`. Prefer [`SharedKey::chat_keys`] for
+/// the on-the-wire `K_conv` / `K_sign` pair.
 #[derive(Debug, Clone)]
 pub struct SharedKey(Keys);
 
 impl SharedKey {
-    /// Derive a shared key from a local secret key and the counterparty's
-    /// public key using the secp256k1 ECDH primitive exposed by
-    /// [`nostr_sdk::util::generate_shared_key`].
+    /// Derive the ECDH shared secret from a local secret key and the
+    /// counterparty's public key.
     ///
     /// Both peers obtain the same `SharedKey` by swapping arguments
     /// (`A.derive(a_sk, b_pk) == B.derive(b_sk, a_pk)`).
@@ -43,37 +44,41 @@ impl SharedKey {
     }
 
     /// Build a `SharedKey` from an already-derived `Keys` value.
-    ///
-    /// Useful when a client persists a freshly-generated `Keys` instead of
-    /// re-deriving it on every load.
     pub fn from_keys(keys: Keys) -> Self {
         Self(keys)
     }
 
-    /// Borrow the underlying `Keys`.
+    /// Borrow the underlying ECDH `Keys` (IKM as a keypair).
+    ///
+    /// For gift-wrap dual-read decrypt only. New envelopes use [`Self::chat_keys`].
     pub fn keys(&self) -> &Keys {
         &self.0
     }
 
-    /// Public key of this shared key — the value used as the `p` tag on
-    /// every gift wrap belonging to the channel.
+    /// Public key of the raw ECDH secret interpreted as a keypair.
+    ///
+    /// This was the GiftWrap `p` tag under the superseded envelope. The new
+    /// envelope uses `pub(K_conv)` from [`Self::chat_keys`] instead.
     pub fn public_key(&self) -> PublicKey {
         self.0.public_key()
     }
 
-    /// Borrow the underlying secret key.
+    /// Borrow the underlying ECDH secret key.
     pub fn secret_key(&self) -> &SecretKey {
         self.0.secret_key()
     }
 
-    /// Serialize the secret as a lower-case hex string suitable for client
-    /// persistence. Pair with [`SharedKey::from_hex`] to round-trip.
+    /// Derive `(K_conv, K_sign)` from this ECDH secret.
+    pub fn chat_keys(&self) -> Result<(Keys, Keys), MostroError> {
+        derive_chat_keys_from_shared(self.secret_key().as_secret_bytes())
+    }
+
+    /// Serialize the ECDH secret as lower-case hex for client persistence.
     pub fn to_hex(&self) -> String {
         self.0.secret_key().to_secret_hex()
     }
 
-    /// Rebuild a `SharedKey` from a hex-encoded secret previously produced
-    /// by [`SharedKey::to_hex`].
+    /// Rebuild from hex previously produced by [`SharedKey::to_hex`].
     pub fn from_hex(hex: &str) -> Result<Self, MostroError> {
         let secret = SecretKey::from_hex(hex).map_err(|e| {
             MostroError::MostroInternalErr(ServiceError::EncryptionError(format!(
@@ -98,6 +103,11 @@ mod tests {
 
         assert_eq!(from_alice.public_key(), from_bob.public_key());
         assert_eq!(from_alice.to_hex(), from_bob.to_hex());
+
+        let (ac, as_) = from_alice.chat_keys().unwrap();
+        let (bc, bs) = from_bob.chat_keys().unwrap();
+        assert_eq!(ac.public_key(), bc.public_key());
+        assert_eq!(as_.public_key(), bs.public_key());
     }
 
     #[test]

--- a/src/chat/unwrap.rs
+++ b/src/chat/unwrap.rs
@@ -1,33 +1,167 @@
-//! Decrypt a Mostro P2P chat gift wrap and verify its inner signature.
+//! Decrypt and validate a Mostro P2P chat envelope.
+//!
+//! [`unwrap_chat_message`] implements the mandatory cheapest-first checks from
+//! <https://mostro.network/protocol/chat.html#client-security-requirements>,
+//! except the caller-owned steps: rate-limit budget, outer-id LRU, and durable
+//! inner-id deduplication.
 
 use nostr_sdk::nips::nip44;
 use nostr_sdk::prelude::*;
 
 use crate::error::{MostroError, ServiceError};
 
+/// Tolerance for clock skew between inner/outer `created_at` and against the
+/// recipient's local clock (absolute future bound). Spec default: 60 seconds.
+pub const CHAT_MAX_CLOCK_SKEW_SECS: u64 = 60;
+
+/// Upper bound on the encrypted outer `content`, enforced before decrypting.
+/// Spec default: 64 KiB.
+pub const CHAT_MAX_CONTENT_BYTES: usize = 64 * 1024;
+
 /// A decrypted P2P chat message.
 #[derive(Debug, Clone)]
 pub struct ChatMessage {
     /// Plain-text body of the inner kind 1 event.
     pub content: String,
-    /// Trade public key of the sender, taken from the inner event's
-    /// signature — already verified by [`unwrap_chat_message`].
+    /// Trade (or admin) public key of the sender — from the verified inner event.
     pub sender: PublicKey,
     /// `created_at` of the inner kind 1 event.
     pub created_at: Timestamp,
+    /// Verified inner event id — retain durably for replay protection.
+    pub inner_event_id: EventId,
+    /// Outer event id — suitable for a bounded LRU against duplicate deliveries.
+    pub outer_event_id: EventId,
 }
 
-/// Unwrap a Mostro P2P chat gift wrap.
+/// Unwrap a kind 14 chat event signed by `K_sign`.
 ///
-/// * `shared_keys` — the `Keys` instance derived from the channel's
-///   [`SharedKey`](super::SharedKey); the secret half is needed to NIP-44
-///   decrypt the outer ciphertext.
-/// * `event` — a kind 1059 event previously fetched from a relay.
+/// * `conv` — `K_conv` (decrypt).
+/// * `sign_pubkey` — `pub(K_sign)` expected as outer author.
+/// * `allowed_signers` — accepted inner pubkeys (buyer+seller trade keys, or
+///   party trade key + admin pubkey for dispute chat).
+/// * `outer` — received kind 14 event.
+/// * `now` — recipient's clock for the absolute future bound.
 ///
-/// On success the inner kind 1 event's signature is verified before
-/// returning, so the [`ChatMessage::sender`] field can be trusted as the
-/// authentic author of the message.
-pub async fn unwrap_chat_message(
+/// Caller must still enforce rate limiting, outer-id LRU, and durable inner-id
+/// dedup using [`ChatMessage::inner_event_id`] / [`ChatMessage::outer_event_id`].
+pub fn unwrap_chat_message(
+    conv: &Keys,
+    sign_pubkey: &PublicKey,
+    allowed_signers: &[PublicKey],
+    outer: &Event,
+    now: Timestamp,
+) -> Result<ChatMessage, MostroError> {
+    // 1. Author
+    if outer.pubkey != *sign_pubkey {
+        return Err(MostroError::MostroInternalErr(
+            ServiceError::UnexpectedError(
+                "outer event is not authored by the conversation signing key".to_string(),
+            ),
+        ));
+    }
+    if outer.kind != Kind::PrivateDirectMessage {
+        return Err(MostroError::MostroInternalErr(
+            ServiceError::UnexpectedError("outer event is not kind 14".to_string()),
+        ));
+    }
+
+    // 2. Exactly one `p` tag equal to pub(K_conv)
+    let mut p_tags = outer.tags.iter().filter(|t| t.kind() == TagKind::p());
+    match (p_tags.next().and_then(|t| t.content()), p_tags.next()) {
+        (Some(pk), None) if pk == conv.public_key().to_hex() => {}
+        _ => {
+            return Err(MostroError::MostroInternalErr(
+                ServiceError::UnexpectedError(
+                    "outer event must carry exactly one p tag for this conversation".to_string(),
+                ),
+            ));
+        }
+    }
+
+    // 3. Absolute timestamp bound against local clock
+    if outer.created_at.as_secs() > now.as_secs().saturating_add(CHAT_MAX_CLOCK_SKEW_SECS) {
+        return Err(MostroError::MostroInternalErr(
+            ServiceError::UnexpectedError("outer event is dated too far in the future".to_string()),
+        ));
+    }
+
+    // 4. Size before crypto
+    if outer.content.len() > CHAT_MAX_CONTENT_BYTES {
+        return Err(MostroError::MostroInternalErr(
+            ServiceError::UnexpectedError(
+                "encrypted payload exceeds the accepted size".to_string(),
+            ),
+        ));
+    }
+
+    // 7. Outer signature (steps 5–6 are caller-owned)
+    outer.verify().map_err(|e| {
+        MostroError::MostroInternalErr(ServiceError::NostrError(format!(
+            "invalid outer chat signature: {e}"
+        )))
+    })?;
+
+    // 8. Decrypt
+    let decrypted =
+        nip44::decrypt(conv.secret_key(), &conv.public_key(), &outer.content).map_err(|e| {
+            MostroError::MostroInternalErr(ServiceError::DecryptionError(format!(
+                "K_conv decrypt failed: {e}"
+            )))
+        })?;
+
+    let inner = Event::from_json(&decrypted).map_err(|e| {
+        MostroError::MostroInternalErr(ServiceError::NostrError(format!(
+            "malformed inner chat event: {e}"
+        )))
+    })?;
+
+    // 9–11. Inner auth
+    inner.verify().map_err(|e| {
+        MostroError::MostroInternalErr(ServiceError::NostrError(format!(
+            "invalid inner chat signature: {e}"
+        )))
+    })?;
+    if !allowed_signers.contains(&inner.pubkey) {
+        return Err(MostroError::MostroInternalErr(
+            ServiceError::UnexpectedError(
+                "inner event is signed by a key that is not a party to this conversation"
+                    .to_string(),
+            ),
+        ));
+    }
+    if inner.kind != Kind::TextNote {
+        return Err(MostroError::MostroInternalErr(
+            ServiceError::UnexpectedError("inner chat event is not a TextNote".to_string()),
+        ));
+    }
+
+    // 13. Relative timestamp bound (step 12 = caller durable inner-id dedup)
+    let skew = inner
+        .created_at
+        .as_secs()
+        .abs_diff(outer.created_at.as_secs());
+    if skew > CHAT_MAX_CLOCK_SKEW_SECS {
+        return Err(MostroError::MostroInternalErr(
+            ServiceError::UnexpectedError(
+                "inner and outer timestamps disagree — stale re-wrap".to_string(),
+            ),
+        ));
+    }
+
+    Ok(ChatMessage {
+        content: inner.content.clone(),
+        sender: inner.pubkey,
+        created_at: inner.created_at,
+        inner_event_id: inner.id,
+        outer_event_id: outer.id,
+    })
+}
+
+/// Legacy gift-wrap unwrap (kind 1059). Prefer [`unwrap_chat_message`].
+///
+/// Kept for dual-read migration: clients MAY accept both envelopes during the
+/// transition window.
+pub async fn unwrap_giftwrap_chat_message(
     shared_keys: &Keys,
     event: &Event,
 ) -> Result<ChatMessage, MostroError> {
@@ -63,8 +197,10 @@ pub async fn unwrap_chat_message(
     })?;
 
     Ok(ChatMessage {
-        content: inner.content,
+        content: inner.content.clone(),
         sender: inner.pubkey,
         created_at: inner.created_at,
+        inner_event_id: inner.id,
+        outer_event_id: event.id,
     })
 }

--- a/src/chat/wrap.rs
+++ b/src/chat/wrap.rs
@@ -1,31 +1,90 @@
-//! Build a Mostro P2P chat gift wrap.
+//! Build a Mostro P2P chat envelope (kind 14 signed by `K_sign`).
 //!
-//! The wire format is a non-standard NIP-59 envelope: a kind 1 text note
-//! signed by the sender's trade key is encrypted with NIP-44 v2 using an
-//! ephemeral key as the encryption side and the **shared key's public key**
-//! as the recipient. The outer kind 1059 event carries that ciphertext, a
-//! `p` tag pointing at the shared pubkey for relay routing, and is signed
-//! with the same ephemeral key.
+//! Wire format (see <https://mostro.network/protocol/chat.html>):
 //!
-//! See <https://mostro.network/protocol/chat.html> for the protocol spec.
+//! ```text
+//! Plain-text message
+//!     -> kind 1 TextNote signed by sender trade key (inner)
+//!     -> NIP-44 v2 self-encrypt under K_conv
+//!     -> kind 14, p = pub(K_conv), signed by K_sign (outer)
+//! ```
+//!
+//! Legacy gift-wrap producers remain available as
+//! [`wrap_giftwrap_chat_message`] for dual-read migration windows.
 
 use nostr_sdk::nips::{nip44, nip59};
 use nostr_sdk::prelude::*;
 
 use crate::error::{MostroError, ServiceError};
 
-/// Wrap a plain-text chat message into a Mostro P2P gift wrap (kind 1059).
+/// Wrap a plain-text chat message into a kind 14 event signed by `K_sign`.
 ///
-/// * `sender_trade_keys` — the sender's per-trade keys; sign the inner kind 1
-///   so the receiver can verify authorship.
-/// * `shared_pubkey` — public key of the [`SharedKey`](super::SharedKey)
-///   shared by the two chat parties; used as the NIP-44 recipient and as
-///   the value of the outer `p` tag.
-/// * `message` — the chat content to deliver.
+/// * `sender_trade_keys` — signs the inner kind 1 (sender authentication).
+/// * `conv` — `K_conv`; NIP-44 self-encryption and the sole outer `p` tag.
+/// * `sign` — `K_sign`; signs the outer event (relay `authors` filter).
+/// * `message` — plain-text body.
 ///
-/// The outer `created_at` is randomized within
-/// [`nip59::RANGE_RANDOM_TIMESTAMP_TWEAK`] to defeat timing correlation.
+/// The inner and outer `created_at` share the same real timestamp (no NIP-59
+/// tweak). Extra `p` tags are rejected so a dispute solver's `#p` query sees
+/// every message the parties see.
 pub async fn wrap_chat_message(
+    sender_trade_keys: &Keys,
+    conv: &Keys,
+    sign: &Keys,
+    message: &str,
+) -> Result<Event, MostroError> {
+    wrap_chat_message_with_tags(sender_trade_keys, conv, sign, message, Vec::new()).await
+}
+
+/// Like [`wrap_chat_message`], but allows additional outer tags that are **not**
+/// `p` tags.
+pub async fn wrap_chat_message_with_tags(
+    sender_trade_keys: &Keys,
+    conv: &Keys,
+    sign: &Keys,
+    message: &str,
+    extra_tags: Vec<Tag>,
+) -> Result<Event, MostroError> {
+    if extra_tags.iter().any(|t| t.kind() == TagKind::p()) {
+        return Err(MostroError::MostroInternalErr(
+            ServiceError::UnexpectedError("extra_tags must not contain a p tag".to_string()),
+        ));
+    }
+
+    // One timestamp for both events: recipients reject a mismatch (replay defense).
+    let now = Timestamp::now();
+
+    let inner = EventBuilder::text_note(message)
+        .custom_created_at(now)
+        .build(sender_trade_keys.public_key())
+        .sign(sender_trade_keys)
+        .await
+        .map_err(|e| MostroError::MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
+
+    // NIP-44 self-encryption: K_conv is both sides of the key exchange.
+    let content = nip44::encrypt(
+        conv.secret_key(),
+        &conv.public_key(),
+        inner.as_json(),
+        nip44::Version::V2,
+    )
+    .map_err(|e| MostroError::MostroInternalErr(ServiceError::EncryptionError(e.to_string())))?;
+
+    let mut tags = vec![Tag::public_key(conv.public_key())];
+    tags.extend(extra_tags);
+
+    EventBuilder::new(Kind::PrivateDirectMessage, content)
+        .tags(tags)
+        .custom_created_at(now)
+        .sign_with_keys(sign)
+        .map_err(|e| MostroError::MostroInternalErr(ServiceError::NostrError(e.to_string())))
+}
+
+/// Legacy gift-wrap producer (kind 1059, ephemeral outer key).
+///
+/// Prefer [`wrap_chat_message`]. Kept for dual-read transition tests and any
+/// client that still needs to emit the superseded envelope during migration.
+pub async fn wrap_giftwrap_chat_message(
     sender_trade_keys: &Keys,
     shared_pubkey: &PublicKey,
     message: &str,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -11,8 +11,10 @@
 //! and maximum rating bounds.
 
 pub use crate::chat::{
-    chat_filter, unwrap_chat_message, wrap_chat_message, ChatMessage, SharedKey,
-    CHAT_DEFAULT_LOOKBACK_SECS,
+    chat_filter, derive_chat_keys, derive_chat_keys_from_shared, giftwrap_chat_filter,
+    unwrap_chat_message, unwrap_giftwrap_chat_message, wrap_chat_message,
+    wrap_giftwrap_chat_message, ChatMessage, SharedKey, CHAT_DEFAULT_LOOKBACK_SECS,
+    CHAT_MAX_CLOCK_SKEW_SECS, CHAT_MAX_CONTENT_BYTES,
 };
 #[cfg(feature = "sqlx")]
 pub use crate::db::Crud;


### PR DESCRIPTION
## Summary
- Migrate `mostro_core::chat` from kind-1059 GiftWrap (ephemeral outer key, `#p` filter) to the [protocol chat v2](https://mostro.network/protocol/chat.html) envelope: HKDF-split `K_conv`/`K_sign`, kind 14 signed by `K_sign`, NIP-44 self-encrypt under `K_conv`.
- Add `derive_chat_keys` / `derive_chat_keys_from_shared`, author-based `chat_filter`, and cheapest-first `unwrap_chat_message` (caller still owns rate-limit / durable inner-id dedup).
- Keep `wrap_giftwrap_chat_message` / `unwrap_giftwrap_chat_message` / `giftwrap_chat_filter` for dual-read during client migration ([mostrix#102](https://github.com/MostroP2P/mostrix/issues/102)).

## Breaking API
- `wrap_chat_message(sender, shared_pubkey, msg)` → `wrap_chat_message(sender, conv, sign, msg)`
- `unwrap_chat_message(shared_keys, event)` → `unwrap_chat_message(conv, sign_pubkey, allowed_signers, event, now)` (sync)
- `chat_filter(shared_pubkey)` → `chat_filter(sign_pubkey)` (`authors`, kind 14)

Version left at `0.14.1` for `cargo release` to bump (suggest **0.15.0** — chat API break).

## Test plan
- [x] `cargo test --lib chat::` — 18 passed (includes protocol test vector pubkeys)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` — 98 lib + doc tests green
- [ ] Reviewer: confirm dual-read giftwrap helpers are enough for Mostrix/mobile transition
- [ ] After merge: release + bump Mostrix / mobile


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a modern encrypted chat format with separate conversation and signing keys.
  * Added validation for message authorship, signatures, timestamps, recipients, and content size.
  * Added support for custom message tags and message event identifiers.
  * Preserved legacy gift-wrapped chat reading and sending for compatibility.
* **Bug Fixes**
  * Improved chat filtering to distinguish direct messages from legacy gift-wrapped messages.
  * Added safeguards for invalid key material and malformed messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->