### PR TITLE
feat: add CantDoReason::MaintenanceMode and an Unknown catch-all

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -105,6 +105,17 @@ pub enum CantDoReason {
     CashuEscrowNotLocked,
     /// A required Cashu signature is missing from the request.
     CashuSignatureMissing,
+    /// Mostro is in maintenance mode (for example draining escrow before a
+    /// Lightning node migration) and is not accepting new orders or takes.
+    /// Actions on already existing orders keep working.
+    MaintenanceMode,
+    /// Catch-all for reasons this build of `mostro-core` does not know yet.
+    ///
+    /// Newer daemons may emit reasons added after this release; without this
+    /// variant the whole `CantDo` payload would fail to deserialize. Never
+    /// emitted by a daemon on purpose.
+    #[serde(other)]
+    Unknown,
 }
 
 /// Internal errors raised by services behind the Mostro API.
@@ -278,5 +289,34 @@ mod tests {
         assert_eq!(json, "\"price_too_stale\"");
         let round: CantDoReason = serde_json::from_str(&json).unwrap();
         assert_eq!(round, CantDoReason::PriceTooStale);
+    }
+    #[test]
+    fn maintenance_mode_serializes_to_snake_case() {
+        let json = serde_json::to_string(&CantDoReason::MaintenanceMode).unwrap();
+        assert_eq!(json, "\"maintenance_mode\"");
+        let round: CantDoReason = serde_json::from_str(&json).unwrap();
+        assert_eq!(round, CantDoReason::MaintenanceMode);
+    }
+
+    #[test]
+    fn unknown_reason_deserializes_to_unknown_catch_all() {
+        let round: CantDoReason = serde_json::from_str("\"reason_from_the_future\"").unwrap();
+        assert_eq!(round, CantDoReason::Unknown);
+    }
+
+    #[test]
+    fn unknown_reason_inside_cant_do_payload_does_not_break_the_message() {
+        let payload: crate::message::Payload =
+            serde_json::from_str(r#"{"cant_do":"reason_from_the_future"}"#).unwrap();
+        assert!(matches!(
+            payload,
+            crate::message::Payload::CantDo(Some(CantDoReason::Unknown))
+        ));
+    }
+
+    #[test]
+    fn unknown_serializes_to_snake_case() {
+        let json = serde_json::to_string(&CantDoReason::Unknown).unwrap();
+        assert_eq!(json, "\"unknown\"");
     }
 }


### PR DESCRIPTION
## Summary

Phase 0 of the maintenance-mode / Lightning node migration spec (MostroP2P/mostro#932).

- **`CantDoReason::MaintenanceMode`** (`"maintenance_mode"`): returned by `mostrod` for `NewOrder` / `TakeBuy` / `TakeSell` while it drains open escrow before switching Lightning nodes. Actions on existing orders are not affected.
- **`CantDoReason::Unknown`** (`#[serde(other)]`): catch-all so a client built against this release keeps parsing `CantDo` payloads that carry reasons added in later releases. Today an unknown reason fails deserialization of the whole payload. Never emitted on purpose by a daemon.

No other API changes. Needs a minor release so `mostrod` can bump its dependency in Phase 1.

## Test plan

- [x] `maintenance_mode_serializes_to_snake_case` — round trip
- [x] `unknown_reason_deserializes_to_unknown_catch_all`
- [x] `unknown_reason_inside_cant_do_payload_does_not_break_the_message` — full `Payload::CantDo` parse
- [x] `unknown_serializes_to_snake_case`
- [x] `cargo test` (102 passed), `cargo clippy --all-targets --all-features` clean, `cargo fmt --check`
- [ ] Protocol book: document the new reason and the upcoming `maintenance_mode` info-event tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ZQvcc8LfrsTYx9VAiSxS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added maintenance mode as a recognized reason when an action cannot be completed.
  * Added graceful handling for unrecognized error reasons, improving compatibility with newer or unexpected responses.
* **Bug Fixes**
  * Unknown reasons are now safely processed both independently and within error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->